### PR TITLE
Revert timeline's sort-order with no-options

### DIFF
--- a/cmd/mstdn/main.go
+++ b/cmd/mstdn/main.go
@@ -197,7 +197,8 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	for _, t := range timeline {
+	for i := len(timeline) - 1; i >= 0; i-- {
+		t := timeline[i]
 		color.Set(color.FgHiRed)
 		fmt.Println(t.Account.Username)
 		color.Set(color.Reset)


### PR DESCRIPTION
Change the shown timeline from older to newer **without** -S option.
Would you consider to merge if there are no problems ?