### PR TITLE
Add GetAccountCurrentUser

### DIFF
--- a/mastodon.go
+++ b/mastodon.go
@@ -215,7 +215,7 @@ func (c *Client) GetAccount(id int) (*Account, error) {
 	return &account, nil
 }
 
-// GetAccountCurrentUser return current user Account.
+// GetAccountCurrentUser return Account of current user.
 func (c *Client) GetAccountCurrentUser() (*Account, error) {
 	var account Account
 	err := c.doAPI("GET", "/api/v1/accounts/verify_credentials", nil, &account)

--- a/mastodon.go
+++ b/mastodon.go
@@ -215,6 +215,16 @@ func (c *Client) GetAccount(id int) (*Account, error) {
 	return &account, nil
 }
 
+// GetAccountCurrentUser return current user Account.
+func (c *Client) GetAccountCurrentUser() (*Account, error) {
+	var account Account
+	err := c.doAPI("GET", "/api/v1/accounts/verify_credentials", nil, &account)
+	if err != nil {
+		return nil, err
+	}
+	return &account, nil
+}
+
 // GetAccountFollowers return followers list.
 func (c *Client) GetAccountFollowers(id int64) ([]*Account, error) {
 	var accounts []*Account


### PR DESCRIPTION
This PR provides the account info get function of the current user.
https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#getting-the-current-user

Usage.

```go
account, err := client.GetAccountCurrentUser()
```