### PR TITLE
Add GetAccountFollowing

### DIFF
--- a/mastodon.go
+++ b/mastodon.go
@@ -235,6 +235,16 @@ func (c *Client) GetAccountFollowers(id int64) ([]*Account, error) {
 	return accounts, nil
 }
 
+// GetAccountFollowing return following list.
+func (c *Client) GetAccountFollowing(id int64) ([]*Account, error) {
+	var accounts []*Account
+	err := c.doAPI("GET", fmt.Sprintf("/api/v1/accounts/%d/following", id), nil, &accounts)
+	if err != nil {
+		return nil, err
+	}
+	return accounts, nil
+}
+
 // GetTimelineHome return statuses from home timeline.
 func (c *Client) GetTimelineHome() ([]*Status, error) {
 	var statuses []*Status


### PR DESCRIPTION
This PR will provide a list of accounts following on mastodon.
https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#getting-who-account-is-following

Usage.

```go
currentUser, err := client.GetAccountCurrentUser()
if err != nil {
	log.Fatal(err)
}

accounts, err := client.GetAccountFollowing(currentUser.ID)
if err != nil {
	log.Fatal(err)
}
```