### PR TITLE
Add ID to Relationship, add follow unfollow test

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -67,11 +67,12 @@ func (c *Client) GetAccountFollowing(id int64) ([]*Account, error) {
 
 // Relationship hold information for relation-ship to the account.
 type Relationship struct {
-	Following  bool `json:"following"`
-	FollowedBy bool `json:"followed_by"`
-	Blocking   bool `json:"blocking"`
-	Muting     bool `json:"muting"`
-	Requested  bool `json:"requested"`
+	ID         int64 `json:"id"`
+	Following  bool  `json:"following"`
+	FollowedBy bool  `json:"followed_by"`
+	Blocking   bool  `json:"blocking"`
+	Muting     bool  `json:"muting"`
+	Requested  bool  `json:"requested"`
 }
 
 // AccountFollow follow the account.

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -1,0 +1,74 @@
+package mastodon
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAccountFollow(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/accounts/1234567/follow" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		fmt.Fprintln(w, `{"id":1234567,"following":true}`)
+		return
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:       ts.URL,
+		ClientID:     "foo",
+		ClientSecret: "bar",
+		AccessToken:  "zoo",
+	})
+	rel, err := client.AccountFollow(123)
+	if err == nil {
+		t.Fatalf("should  be fail: %v", err)
+	}
+	rel, err = client.AccountFollow(1234567)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if rel.ID != 1234567 {
+		t.Fatalf("want %d but %d", 1234567, rel.ID)
+	}
+	if !rel.Following {
+		t.Fatalf("want %t but %t", true, rel.Following)
+	}
+}
+
+func TestAccountUnfollow(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/accounts/1234567/unfollow" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		fmt.Fprintln(w, `{"id":1234567,"following":false}`)
+		return
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:       ts.URL,
+		ClientID:     "foo",
+		ClientSecret: "bar",
+		AccessToken:  "zoo",
+	})
+	rel, err := client.AccountUnfollow(123)
+	if err == nil {
+		t.Fatalf("should be fail: %v", err)
+	}
+	rel, err = client.AccountUnfollow(1234567)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if rel.ID != 1234567 {
+		t.Fatalf("want %d but %d", 1234567, rel.ID)
+	}
+	if rel.Following {
+		t.Fatalf("want %t but %t", false, rel.Following)
+	}
+}


### PR DESCRIPTION
Since the item of ID was included in Relationship, it added.

```
$ curl -X POST -H 'Authorization: Bearer xxxTOKENxxx' https://mstdn.jp/api/v1/accounts/4880/follow
{"id":4880,"following":true,"followed_by":true,"blocking":false,"muting":false,"requested":false}

$ curl -X POST -H 'Authorization: Bearer xxxTOKENxxx' https://mstdn.jp/api/v1/accounts/4880/unfollow
{"id":4880,"following":false,"followed_by":true,"blocking":false,"muting":false,"requested":false}
```

And, add AccountFollow and AccountUnfollow test.