### PR TITLE
Fix var name url to u

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -45,13 +45,13 @@ func RegisterApp(appConfig *AppConfig) (*Application, error) {
 	params.Set("scopes", appConfig.Scopes)
 	params.Set("website", appConfig.Website)
 
-	url, err := url.Parse(appConfig.Server)
+	u, err := url.Parse(appConfig.Server)
 	if err != nil {
 		return nil, err
 	}
-	url.Path = path.Join(url.Path, "/api/v1/apps")
+	u.Path = path.Join(u.Path, "/api/v1/apps")
 
-	req, err := http.NewRequest(http.MethodPost, url.String(), strings.NewReader(params.Encode()))
+	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(params.Encode()))
 	if err != nil {
 		return nil, err
 	}

--- a/mastodon.go
+++ b/mastodon.go
@@ -24,14 +24,14 @@ type Client struct {
 }
 
 func (c *Client) doAPI(method string, uri string, params url.Values, res interface{}) error {
-	url, err := url.Parse(c.config.Server)
+	u, err := url.Parse(c.config.Server)
 	if err != nil {
 		return err
 	}
-	url.Path = path.Join(url.Path, uri)
+	u.Path = path.Join(u.Path, uri)
 
 	var resp *http.Response
-	req, err := http.NewRequest(method, url.String(), strings.NewReader(params.Encode()))
+	req, err := http.NewRequest(method, u.String(), strings.NewReader(params.Encode()))
 	if err != nil {
 		return err
 	}
@@ -70,13 +70,13 @@ func (c *Client) Authenticate(username, password string) error {
 	params.Set("password", password)
 	params.Set("scope", "read write follow")
 
-	url, err := url.Parse(c.config.Server)
+	u, err := url.Parse(c.config.Server)
 	if err != nil {
 		return err
 	}
-	url.Path = path.Join(url.Path, "/oauth/token")
+	u.Path = path.Join(u.Path, "/oauth/token")
 
-	req, err := http.NewRequest(http.MethodPost, url.String(), strings.NewReader(params.Encode()))
+	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(params.Encode()))
 	if err != nil {
 		return err
 	}

--- a/streaming.go
+++ b/streaming.go
@@ -69,11 +69,11 @@ func handleReader(ctx context.Context, q chan Event, r io.Reader) error {
 
 // StreamingPublic return channel to read events.
 func (c *Client) StreamingPublic(ctx context.Context) (chan Event, error) {
-	url, err := url.Parse(c.config.Server)
+	u, err := url.Parse(c.config.Server)
 	if err != nil {
 		return nil, err
 	}
-	url.Path = path.Join(url.Path, "/api/v1/streaming/public")
+	u.Path = path.Join(u.Path, "/api/v1/streaming/public")
 
 	var resp *http.Response
 
@@ -82,7 +82,7 @@ func (c *Client) StreamingPublic(ctx context.Context) (chan Event, error) {
 		defer ctx.Done()
 
 		for {
-			req, err := http.NewRequest(http.MethodGet, url.String(), nil)
+			req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 			if err == nil {
 				req.Header.Set("Authorization", "Bearer "+c.config.AccessToken)
 				resp, err = c.Do(req)


### PR DESCRIPTION
When I first sent PR, I used url as a variable name.

```go
url, err := url.Parse(c.config.Server)
```

But, since it is the same name as the package name, it causes confusion when reading the source code.
Also, after that, the url package can not be used.

```go
url, _ := url.Parse("http://example.com/")
fmt.Println(url.String())

v := url.Values{} // url.Values undefined (type *url.URL has no field or method Values)
```

https://play.golang.org/p/0P8F1o6Kka

So, fixed the variable name "url" to "u".