### PR TITLE
Add AccountUpdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ if err != nil {
 
 * [x] GET /api/v1/accounts/:id
 * [x] GET /api/v1/accounts/verify_credentials
+* [ ] PATCH /api/v1/accounts/update_credentials
 * [x] GET /api/v1/accounts/:id/followers
 * [x] GET /api/v1/accounts/:id/following
 * [ ] GET /api/v1/accounts/:id/statuses

--- a/accounts.go
+++ b/accounts.go
@@ -46,6 +46,42 @@ func (c *Client) GetAccountCurrentUser() (*Account, error) {
 	return &account, nil
 }
 
+// Profile is a struct for updating profiles.
+type Profile struct {
+	// If it is nil it will not be updated.
+	// If it is empty, update it with empty.
+	DisplayName *string
+	Note        *string
+
+	// Set the base64 encoded character string of the image.
+	Avatar string
+	Header string
+}
+
+// AccountUpdate updates the information of the current user.
+func (c *Client) AccountUpdate(profile *Profile) (*Account, error) {
+	params := url.Values{}
+	if profile.DisplayName != nil {
+		params.Set("display_name", *profile.DisplayName)
+	}
+	if profile.Note != nil {
+		params.Set("note", *profile.Note)
+	}
+	if profile.Avatar != "" {
+		params.Set("avatar", profile.Avatar)
+	}
+	if profile.Header != "" {
+		params.Set("header", profile.Header)
+	}
+
+	var account Account
+	err := c.doAPI(http.MethodPatch, "/api/v1/accounts/update_credentials", params, &account)
+	if err != nil {
+		return nil, err
+	}
+	return &account, nil
+}
+
 // GetAccountFollowers return followers list.
 func (c *Client) GetAccountFollowers(id int64) ([]*Account, error) {
 	var accounts []*Account

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -34,8 +34,6 @@ func TestAccountUpdate(t *testing.T) {
 	}
 }
 
-func String(v string) *string { return &v }
-
 func TestGetBlocks(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, `[{"Username": "foo"}, {"Username": "bar"}]`)

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -7,6 +7,35 @@ import (
 	"testing"
 )
 
+func TestAccountUpdate(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"Username": "zzz"}`)
+		return
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:       ts.URL,
+		ClientID:     "foo",
+		ClientSecret: "bar",
+		AccessToken:  "zoo",
+	})
+	a, err := client.AccountUpdate(&Profile{
+		DisplayName: String("display_name"),
+		Note:        String("note"),
+		Avatar:      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUoAAADrCAYAAAA...",
+		Header:      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUoAAADrCAYAAAA...",
+	})
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if a.Username != "zzz" {
+		t.Fatalf("want %q but %q", "zzz", a.Username)
+	}
+}
+
+func String(v string) *string { return &v }
+
 func TestGetBlocks(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, `[{"Username": "foo"}, {"Username": "bar"}]`)

--- a/helper.go
+++ b/helper.go
@@ -1,0 +1,36 @@
+package mastodon
+
+import (
+	"encoding/base64"
+	"net/http"
+	"os"
+)
+
+func Base64EncodeFileName(filename string) (string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	return Base64Encode(file)
+}
+
+func Base64Encode(file *os.File) (string, error) {
+	fi, err := file.Stat()
+	if err != nil {
+		return "", err
+	}
+
+	d := make([]byte, fi.Size())
+	_, err = file.Read(d)
+	if err != nil {
+		return "", err
+	}
+
+	return "data:" + http.DetectContentType(d) +
+		";base64," + base64.StdEncoding.EncodeToString(d), nil
+}
+
+// String is a helper function to get the pointer value of a string.
+func String(v string) *string { return &v }

--- a/helper.go
+++ b/helper.go
@@ -6,6 +6,7 @@ import (
 	"os"
 )
 
+// Base64EncodeFileName returns the base64 data URI format string of the file with the file name.
 func Base64EncodeFileName(filename string) (string, error) {
 	file, err := os.Open(filename)
 	if err != nil {
@@ -16,6 +17,7 @@ func Base64EncodeFileName(filename string) (string, error) {
 	return Base64Encode(file)
 }
 
+// Base64Encode returns the base64 data URI format string of the file.
 func Base64Encode(file *os.File) (string, error) {
 	fi, err := file.Stat()
 	if err != nil {

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,0 +1,13 @@
+package mastodon
+
+import (
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	s := "test"
+	sp := String(s)
+	if *sp != s {
+		t.Fatalf("want %q but %q", s, *sp)
+	}
+}

--- a/mastodon.go
+++ b/mastodon.go
@@ -36,6 +36,9 @@ func (c *Client) doAPI(method string, uri string, params url.Values, res interfa
 		return err
 	}
 	req.Header.Set("Authorization", "Bearer "+c.config.AccessToken)
+	if params != nil {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
 	resp, err = c.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR provides the profile update function of the current user.
https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#updating-the-current-user

Usage.

```go
avatarImg, err := mastodon.Base64EncodeFileName("avatar.jpg")
headerImg, err := mastodon.Base64EncodeFileName("header.jpg")
account, err := client.AccountUpdate(&mastodon.Profile{
	DisplayName: mastodon.String("foobar"),
	Note:        mastodon.String("Hello, World!"),
	Avatar:      avatarImg,
	Header:      headerImg,
})
```

I will explain PR.

Since mastodon ignored updating unless Content-Type is set in PATCH method, we modified to set Content-Type:application/x-www-form-urlencoded if params is not nil.

Since Profile's DisplayName and Note differ in behavior when not setting and when setting empty, we adopt character string pointer type.
I also add a function to convert a character string to a pointer type in a helper.
Like [github.com/google/go-github/github#String](https://godoc.org/github.com/google/go-github/github#String).

Since Avatar and Header are not deleted even if empty is set, they are left as string type.

Since Avatar and Header request base64 data URI, we also added helper functions to create base64 data URIs from files and file names.

Since the test of Base64EncodeFileName and Base64Encode is necessary to keep the image file in the repository, it is not currently written.
If you do not mind including the test image in the repository, I will write a test.