### PR TITLE
Add reblog and favorite API

### DIFF
--- a/status.go
+++ b/status.go
@@ -85,10 +85,20 @@ func (c *Client) GetStatusCard(id string) (*Card, error) {
 	return &card, nil
 }
 
-// GetRebloggedBy returns the account of the user who re-blogged.
+// GetRebloggedBy returns the account list of the user who reblogged the toot of id.
 func (c *Client) GetRebloggedBy(id int64) ([]*Account, error) {
 	var accounts []*Account
 	err := c.doAPI(http.MethodGet, fmt.Sprintf("/api/v1/statuses/%d/reblogged_by", id), nil, &accounts)
+	if err != nil {
+		return nil, err
+	}
+	return accounts, nil
+}
+
+// GetFavouritedBy returns the account list of the user who liked the toot of id.
+func (c *Client) GetFavouritedBy(id int64) ([]*Account, error) {
+	var accounts []*Account
+	err := c.doAPI(http.MethodGet, fmt.Sprintf("/api/v1/statuses/%d/favourited_by", id), nil, &accounts)
 	if err != nil {
 		return nil, err
 	}

--- a/status.go
+++ b/status.go
@@ -56,7 +56,7 @@ func (c *Client) GetFavourites() ([]*Status, error) {
 }
 
 // GetStatus return status specified by id.
-func (c *Client) GetStatus(id string) (*Status, error) {
+func (c *Client) GetStatus(id int64) (*Status, error) {
 	var status Status
 	err := c.doAPI(http.MethodGet, fmt.Sprintf("/api/v1/statuses/%d", id), nil, &status)
 	if err != nil {
@@ -66,7 +66,7 @@ func (c *Client) GetStatus(id string) (*Status, error) {
 }
 
 // GetStatusContext return status specified by id.
-func (c *Client) GetStatusContext(id string) (*Context, error) {
+func (c *Client) GetStatusContext(id int64) (*Context, error) {
 	var context Context
 	err := c.doAPI(http.MethodGet, fmt.Sprintf("/api/v1/statuses/%d/context", id), nil, &context)
 	if err != nil {
@@ -76,7 +76,7 @@ func (c *Client) GetStatusContext(id string) (*Context, error) {
 }
 
 // GetStatusCard return status specified by id.
-func (c *Client) GetStatusCard(id string) (*Card, error) {
+func (c *Client) GetStatusCard(id int64) (*Card, error) {
 	var card Card
 	err := c.doAPI(http.MethodGet, fmt.Sprintf("/api/v1/statuses/%d/card", id), nil, &card)
 	if err != nil {

--- a/status.go
+++ b/status.go
@@ -105,6 +105,26 @@ func (c *Client) GetFavouritedBy(id int64) ([]*Account, error) {
 	return accounts, nil
 }
 
+// Reblog is reblog the toot of id.
+func (c *Client) Reblog(id int64) (*Status, error) {
+	var status Status
+	err := c.doAPI(http.MethodPost, fmt.Sprintf("/api/v1/statuses/%d/reblog", id), nil, &status)
+	if err != nil {
+		return nil, err
+	}
+	return &status, nil
+}
+
+// Unreblog is unreblog the toot of id.
+func (c *Client) Unreblog(id int64) (*Status, error) {
+	var status Status
+	err := c.doAPI(http.MethodPost, fmt.Sprintf("/api/v1/statuses/%d/unreblog", id), nil, &status)
+	if err != nil {
+		return nil, err
+	}
+	return &status, nil
+}
+
 // GetTimelineHome return statuses from home timeline.
 func (c *Client) GetTimelineHome() ([]*Status, error) {
 	var statuses []*Status

--- a/status.go
+++ b/status.go
@@ -105,7 +105,7 @@ func (c *Client) GetFavouritedBy(id int64) ([]*Account, error) {
 	return accounts, nil
 }
 
-// Reblog is reblog the toot of id.
+// Reblog is reblog the toot of id and return status of reblog.
 func (c *Client) Reblog(id int64) (*Status, error) {
 	var status Status
 	err := c.doAPI(http.MethodPost, fmt.Sprintf("/api/v1/statuses/%d/reblog", id), nil, &status)
@@ -115,7 +115,7 @@ func (c *Client) Reblog(id int64) (*Status, error) {
 	return &status, nil
 }
 
-// Unreblog is unreblog the toot of id.
+// Unreblog is unreblog the toot of id and return status of the original toot.
 func (c *Client) Unreblog(id int64) (*Status, error) {
 	var status Status
 	err := c.doAPI(http.MethodPost, fmt.Sprintf("/api/v1/statuses/%d/unreblog", id), nil, &status)

--- a/status.go
+++ b/status.go
@@ -125,6 +125,26 @@ func (c *Client) Unreblog(id int64) (*Status, error) {
 	return &status, nil
 }
 
+// Favourite is favourite the toot of id and return status of the favourite toot.
+func (c *Client) Favourite(id int64) (*Status, error) {
+	var status Status
+	err := c.doAPI(http.MethodPost, fmt.Sprintf("/api/v1/statuses/%d/favourite", id), nil, &status)
+	if err != nil {
+		return nil, err
+	}
+	return &status, nil
+}
+
+// Unfavourite is unfavourite the toot of id and return status of the unfavourite toot.
+func (c *Client) Unfavourite(id int64) (*Status, error) {
+	var status Status
+	err := c.doAPI(http.MethodPost, fmt.Sprintf("/api/v1/statuses/%d/unfavourite", id), nil, &status)
+	if err != nil {
+		return nil, err
+	}
+	return &status, nil
+}
+
 // GetTimelineHome return statuses from home timeline.
 func (c *Client) GetTimelineHome() ([]*Status, error) {
 	var statuses []*Status

--- a/status.go
+++ b/status.go
@@ -85,6 +85,16 @@ func (c *Client) GetStatusCard(id string) (*Card, error) {
 	return &card, nil
 }
 
+// GetRebloggedBy returns the account of the user who re-blogged.
+func (c *Client) GetRebloggedBy(id int64) ([]*Account, error) {
+	var accounts []*Account
+	err := c.doAPI(http.MethodGet, fmt.Sprintf("/api/v1/statuses/%d/reblogged_by", id), nil, &accounts)
+	if err != nil {
+		return nil, err
+	}
+	return accounts, nil
+}
+
 // GetTimelineHome return statuses from home timeline.
 func (c *Client) GetTimelineHome() ([]*Status, error) {
 	var statuses []*Status

--- a/status_test.go
+++ b/status_test.go
@@ -70,3 +70,39 @@ func TestGetRebloggedBy(t *testing.T) {
 		t.Fatalf("want %q but %q", "bar", rbs[0].Username)
 	}
 }
+
+func TestGetFavouritedBy(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/statuses/1234567/favourited_by" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		fmt.Fprintln(w, `[{"Username": "foo"}, {"Username": "bar"}]`)
+		return
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:       ts.URL,
+		ClientID:     "foo",
+		ClientSecret: "bar",
+		AccessToken:  "zoo",
+	})
+	_, err := client.GetFavouritedBy(123)
+	if err == nil {
+		t.Fatalf("should be fail: %v", err)
+	}
+	fbs, err := client.GetFavouritedBy(1234567)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if len(fbs) != 2 {
+		t.Fatalf("result should be two: %d", len(fbs))
+	}
+	if fbs[0].Username != "foo" {
+		t.Fatalf("want %q but %q", "foo", fbs[0].Username)
+	}
+	if fbs[1].Username != "bar" {
+		t.Fatalf("want %q but %q", "bar", fbs[0].Username)
+	}
+}

--- a/status_test.go
+++ b/status_test.go
@@ -34,3 +34,39 @@ func TestGetFavourites(t *testing.T) {
 		t.Fatalf("want %q but %q", "bar", favs[1].Content)
 	}
 }
+
+func TestGetRebloggedBy(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/statuses/1234567/reblogged_by" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		fmt.Fprintln(w, `[{"Username": "foo"}, {"Username": "bar"}]`)
+		return
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:       ts.URL,
+		ClientID:     "foo",
+		ClientSecret: "bar",
+		AccessToken:  "zoo",
+	})
+	_, err := client.GetRebloggedBy(123)
+	if err == nil {
+		t.Fatalf("should be fail: %v", err)
+	}
+	rbs, err := client.GetRebloggedBy(1234567)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if len(rbs) != 2 {
+		t.Fatalf("result should be two: %d", len(rbs))
+	}
+	if rbs[0].Username != "foo" {
+		t.Fatalf("want %q but %q", "foo", rbs[0].Username)
+	}
+	if rbs[1].Username != "bar" {
+		t.Fatalf("want %q but %q", "bar", rbs[0].Username)
+	}
+}

--- a/status_test.go
+++ b/status_test.go
@@ -106,3 +106,63 @@ func TestGetFavouritedBy(t *testing.T) {
 		t.Fatalf("want %q but %q", "bar", fbs[0].Username)
 	}
 }
+
+func TestReblog(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/statuses/1234567/reblog" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		fmt.Fprintln(w, `{"Content": "zzz"}`)
+		return
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:       ts.URL,
+		ClientID:     "foo",
+		ClientSecret: "bar",
+		AccessToken:  "zoo",
+	})
+	_, err := client.Reblog(123)
+	if err == nil {
+		t.Fatalf("should be fail: %v", err)
+	}
+	status, err := client.Reblog(1234567)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if status.Content != "zzz" {
+		t.Fatalf("want %q but %q", "zzz", status.Content)
+	}
+}
+
+func TestUnreblog(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/statuses/1234567/unreblog" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		fmt.Fprintln(w, `{"Content": "zzz"}`)
+		return
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:       ts.URL,
+		ClientID:     "foo",
+		ClientSecret: "bar",
+		AccessToken:  "zoo",
+	})
+	_, err := client.Unreblog(123)
+	if err == nil {
+		t.Fatalf("should be fail: %v", err)
+	}
+	status, err := client.Unreblog(1234567)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if status.Content != "zzz" {
+		t.Fatalf("want %q but %q", "zzz", status.Content)
+	}
+}

--- a/status_test.go
+++ b/status_test.go
@@ -35,6 +35,36 @@ func TestGetFavourites(t *testing.T) {
 	}
 }
 
+func TestGetStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/statuses/1234567" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		fmt.Fprintln(w, `{"Content": "zzz"}`)
+		return
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:       ts.URL,
+		ClientID:     "foo",
+		ClientSecret: "bar",
+		AccessToken:  "zoo",
+	})
+	_, err := client.GetStatus(123)
+	if err == nil {
+		t.Fatalf("should be fail: %v", err)
+	}
+	status, err := client.GetStatus(1234567)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if status.Content != "zzz" {
+		t.Fatalf("want %q but %q", "zzz", status.Content)
+	}
+}
+
 func TestGetRebloggedBy(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/statuses/1234567/reblogged_by" {

--- a/status_test.go
+++ b/status_test.go
@@ -166,3 +166,63 @@ func TestUnreblog(t *testing.T) {
 		t.Fatalf("want %q but %q", "zzz", status.Content)
 	}
 }
+
+func TestFavourite(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/statuses/1234567/favourite" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		fmt.Fprintln(w, `{"Content": "zzz"}`)
+		return
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:       ts.URL,
+		ClientID:     "foo",
+		ClientSecret: "bar",
+		AccessToken:  "zoo",
+	})
+	_, err := client.Favourite(123)
+	if err == nil {
+		t.Fatalf("should be fail: %v", err)
+	}
+	status, err := client.Favourite(1234567)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if status.Content != "zzz" {
+		t.Fatalf("want %q but %q", "zzz", status.Content)
+	}
+}
+
+func TestUnfavourite(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/statuses/1234567/unfavourite" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		fmt.Fprintln(w, `{"Content": "zzz"}`)
+		return
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:       ts.URL,
+		ClientID:     "foo",
+		ClientSecret: "bar",
+		AccessToken:  "zoo",
+	})
+	_, err := client.Unfavourite(123)
+	if err == nil {
+		t.Fatalf("should be fail: %v", err)
+	}
+	status, err := client.Unfavourite(1234567)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if status.Content != "zzz" {
+		t.Fatalf("want %q but %q", "zzz", status.Content)
+	}
+}


### PR DESCRIPTION
This PR provides reblog and favorite API.

* [x] GET /api/v1/statuses/:id/reblogged_by
* [x] GET /api/v1/statuses/:id/favourited_by
* [x] POST /api/v1/statuses/:id/reblog
* [x] POST /api/v1/statuses/:id/unreblog
* [x] POST /api/v1/statuses/:id/favourite
* [x] POST /api/v1/statuses/:id/unfavourite