### PR TITLE
Add FollowRequestAuthorize and FollowRequestReject

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ if err != nil {
 * [x] GET /api/v1/blocks
 * [x] GET /api/v1/favourites
 * [x] GET /api/v1/follow_requests
-* [ ] POST /api/v1/follow_requests/authorize
-* [ ] POST /api/v1/follow_requests/reject
+* [ ] POST /api/v1/follow_requests/:id/authorize
+* [ ] POST /api/v1/follow_requests/:id/reject
 * [x] POST /api/v1/follows
 * [x] GET /api/v1/instance
 * [ ] POST /api/v1/media

--- a/accounts.go
+++ b/accounts.go
@@ -241,3 +241,13 @@ func (c *Client) GetFollowRequests() ([]*Account, error) {
 	}
 	return accounts, nil
 }
+
+// FollowRequestAuthorize is authorize the follow request of user with id.
+func (c *Client) FollowRequestAuthorize(id int64) error {
+	return c.doAPI(http.MethodPost, fmt.Sprintf("/api/v1/follow_requests/%d/authorize", id), nil, nil)
+}
+
+// FollowRequestReject is rejects the follow request of user with id.
+func (c *Client) FollowRequestReject(id int64) error {
+	return c.doAPI(http.MethodPost, fmt.Sprintf("/api/v1/follow_requests/%d/reject", id), nil, nil)
+}

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -155,3 +155,51 @@ func TestGetFollowRequests(t *testing.T) {
 		t.Fatalf("want %q but %q", "bar", fReqs[0].Username)
 	}
 }
+
+func TestFollowRequestAuthorize(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/follow_requests/1234567/authorize" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:       ts.URL,
+		ClientID:     "foo",
+		ClientSecret: "bar",
+		AccessToken:  "zoo",
+	})
+	err := client.FollowRequestAuthorize(123)
+	if err == nil {
+		t.Fatalf("should be fail: %v", err)
+	}
+	err = client.FollowRequestAuthorize(1234567)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+}
+
+func TestFollowRequestReject(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/follow_requests/1234567/reject" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:       ts.URL,
+		ClientID:     "foo",
+		ClientSecret: "bar",
+		AccessToken:  "zoo",
+	})
+	err := client.FollowRequestReject(123)
+	if err == nil {
+		t.Fatalf("should be fail: %v", err)
+	}
+	err = client.FollowRequestReject(1234567)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+}

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -129,7 +129,13 @@ func TestAccountUnfollow(t *testing.T) {
 }
 
 func TestGetFollowRequests(t *testing.T) {
+	canErr := true
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if canErr {
+			canErr = false
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 		fmt.Fprintln(w, `[{"Username": "foo"}, {"Username": "bar"}]`)
 		return
 	}))
@@ -141,6 +147,10 @@ func TestGetFollowRequests(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
+	_, err := client.GetFollowRequests()
+	if err == nil {
+		t.Fatalf("should be fail: %v", err)
+	}
 	fReqs, err := client.GetFollowRequests()
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)

--- a/mastodon.go
+++ b/mastodon.go
@@ -44,12 +44,11 @@ func (c *Client) doAPI(method string, uri string, params url.Values, res interfa
 		return err
 	}
 	defer resp.Body.Close()
-	if res == nil {
-		return nil
-	}
 
-	if method == http.MethodGet && resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("bad request: %v", resp.Status)
+	} else if res == nil {
+		return nil
 	}
 
 	return json.NewDecoder(resp.Body).Decode(&res)


### PR DESCRIPTION
This PR provides follow request authorize/reject function.

If there is empty response, error handling of doAPI has been corrected since it will not result in an error even if an error is returned with http status.

Fix TestGetFollowRequests to generate errors in order to cover the error test of GetFollowRequests.