### PR TITLE
Fix tty.Open() position

### DIFF
--- a/cmd/mstdn/main.go
+++ b/cmd/mstdn/main.go
@@ -66,12 +66,6 @@ var (
 )
 
 func prompt() (string, string, error) {
-	t, err := tty.Open()
-	if err != nil {
-		return "", "", err
-	}
-	defer t.Close()
-
 	fmt.Print("E-Mail: ")
 	email, err := readUsername()
 	if err != nil {
@@ -81,6 +75,11 @@ func prompt() (string, string, error) {
 	fmt.Print("Password: ")
 	var password string
 	if readPassword == nil {
+		t, err := tty.Open()
+		if err != nil {
+			return "", "", err
+		}
+		defer t.Close()
 		password, err = t.ReadPassword()
 	} else {
 		password, err = readPassword()


### PR DESCRIPTION
There was a problem that you can not enter E-Mail with macOS, so I fixed it.

### Environment Details

OS: macOS Sierra 10.12.4
Terminal: iTerm2 Build 3.0.15