### PR TITLE
Correct context uses

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -55,6 +55,7 @@ func RegisterApp(ctx context.Context, appConfig *AppConfig) (*Application, error
 	if err != nil {
 		return nil, err
 	}
+	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := appConfig.Do(req)
 	if err != nil {

--- a/apps_test.go
+++ b/apps_test.go
@@ -52,7 +52,7 @@ func TestRegisterAppWithCancel(t *testing.T) {
 	defer ts.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go cancel()
+	cancel()
 	_, err := RegisterApp(ctx, &AppConfig{
 		Server: ts.URL,
 		Scopes: "read write follow",

--- a/apps_test.go
+++ b/apps_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestRegisterApp(t *testing.T) {
@@ -39,5 +40,27 @@ func TestRegisterApp(t *testing.T) {
 	}
 	if app.ClientSecret != "bar" {
 		t.Fatalf("want %q but %q", "bar", app.ClientSecret)
+	}
+}
+
+func TestRegisterAppWithCancel(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(3 * time.Second)
+		fmt.Fprintln(w, `{"client_id": "foo", "client_secret": "bar"}`)
+		return
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go cancel()
+	_, err := RegisterApp(ctx, &AppConfig{
+		Server: ts.URL,
+		Scopes: "read write follow",
+	})
+	if err == nil {
+		t.Fatalf("should be fail: %v", err)
+	}
+	if want := "Post " + ts.URL + "/api/v1/apps: context canceled"; want != err.Error() {
+		t.Fatalf("want %q but %q", want, err.Error())
 	}
 }

--- a/mastodon.go
+++ b/mastodon.go
@@ -129,7 +129,7 @@ func (c *Client) doAPI(ctx context.Context, method string, uri string, params in
 	} else {
 		req, err = http.NewRequest(method, u.String(), nil)
 	}
-	req.WithContext(ctx)
+	req = req.WithContext(ctx)
 	req.Header.Set("Authorization", "Bearer "+c.config.AccessToken)
 	if params != nil {
 		req.Header.Set("Content-Type", ct)
@@ -191,6 +191,7 @@ func (c *Client) Authenticate(ctx context.Context, username, password string) er
 	if err != nil {
 		return err
 	}
+	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := c.Do(req)
 	if err != nil {

--- a/mastodon_test.go
+++ b/mastodon_test.go
@@ -56,7 +56,7 @@ func TestAuthenticateWithCancel(t *testing.T) {
 		ClientSecret: "bar",
 	})
 	ctx, cancel := context.WithCancel(context.Background())
-	go cancel()
+	cancel()
 	err := client.Authenticate(ctx, "invalid", "user")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
@@ -116,7 +116,7 @@ func TestPostStatusWithCancel(t *testing.T) {
 		ClientSecret: "bar",
 	})
 	ctx, cancel := context.WithCancel(context.Background())
-	go cancel()
+	cancel()
 	_, err := client.PostStatus(ctx, &Toot{
 		Status: "foobar",
 	})
@@ -182,7 +182,7 @@ func TestGetTimelineHomeWithCancel(t *testing.T) {
 		AccessToken:  "zoo",
 	})
 	ctx, cancel := context.WithCancel(context.Background())
-	go cancel()
+	cancel()
 	_, err := client.GetTimelineHome(ctx)
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)

--- a/streaming.go
+++ b/streaming.go
@@ -89,6 +89,7 @@ func (c *Client) streaming(ctx context.Context, p string, params url.Values) (ch
 			}
 			req, err := http.NewRequest(http.MethodGet, u.String(), in)
 			if err == nil {
+				req = req.WithContext(ctx)
 				req.Header.Set("Authorization", "Bearer "+c.config.AccessToken)
 				resp, err = c.Do(req)
 				if resp != nil && resp.StatusCode != http.StatusOK {
@@ -114,7 +115,6 @@ func (c *Client) streaming(ctx context.Context, p string, params url.Values) (ch
 		}
 	}()
 	return q, nil
-
 }
 
 // StreamingPublic return channel to read events on public.


### PR DESCRIPTION
`doAPI`'s `context` does not work due to `WithContext` immutability. `Authenticate` and `RegisterApp` does not use `context` although they needs `context`, so their `context` does not work also. This pull request fixes them and adds test cases.