### PR TITLE
Fix test json property name

### DIFF
--- a/accounts_test.go
+++ b/accounts_test.go
@@ -14,7 +14,7 @@ func TestGetAccount(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
-		fmt.Fprintln(w, `{"Username": "zzz"}`)
+		fmt.Fprintln(w, `{"username": "zzz"}`)
 		return
 	}))
 	defer ts.Close()
@@ -46,7 +46,7 @@ func TestGetAccountCurrentUser(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-		fmt.Fprintln(w, `{"Username": "zzz"}`)
+		fmt.Fprintln(w, `{"username": "zzz"}`)
 		return
 	}))
 	defer ts.Close()
@@ -78,7 +78,7 @@ func TestAccountUpdate(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-		fmt.Fprintln(w, `{"Username": "zzz"}`)
+		fmt.Fprintln(w, `{"username": "zzz"}`)
 		return
 	}))
 	defer ts.Close()
@@ -113,7 +113,7 @@ func TestGetAccountStatuses(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
-		fmt.Fprintln(w, `[{"Content": "foo"}, {"Content": "bar"}]`)
+		fmt.Fprintln(w, `[{"content": "foo"}, {"content": "bar"}]`)
 		return
 	}))
 	defer ts.Close()
@@ -146,7 +146,7 @@ func TestGetAccountFollowers(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
-		fmt.Fprintln(w, `[{"Username": "foo"}, {"Username": "bar"}]`)
+		fmt.Fprintln(w, `[{"username": "foo"}, {"username": "bar"}]`)
 		return
 	}))
 	defer ts.Close()
@@ -182,7 +182,7 @@ func TestGetAccountFollowing(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
-		fmt.Fprintln(w, `[{"Username": "foo"}, {"Username": "bar"}]`)
+		fmt.Fprintln(w, `[{"username": "foo"}, {"username": "bar"}]`)
 		return
 	}))
 	defer ts.Close()
@@ -220,7 +220,7 @@ func TestGetBlocks(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-		fmt.Fprintln(w, `[{"Username": "foo"}, {"Username": "bar"}]`)
+		fmt.Fprintln(w, `[{"username": "foo"}, {"username": "bar"}]`)
 		return
 	}))
 	defer ts.Close()
@@ -487,7 +487,7 @@ func TestAccountsSearch(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-		fmt.Fprintln(w, `[{"Username": "foobar"}, {"Username": "barfoo"}]`)
+		fmt.Fprintln(w, `[{"username": "foobar"}, {"username": "barfoo"}]`)
 		return
 	}))
 	defer ts.Close()
@@ -523,7 +523,7 @@ func TestFollowRemoteUser(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-		fmt.Fprintln(w, `{"Username": "zzz"}`)
+		fmt.Fprintln(w, `{"username": "zzz"}`)
 		return
 	}))
 	defer ts.Close()
@@ -555,7 +555,7 @@ func TestGetFollowRequests(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-		fmt.Fprintln(w, `[{"Username": "foo"}, {"Username": "bar"}]`)
+		fmt.Fprintln(w, `[{"username": "foo"}, {"username": "bar"}]`)
 		return
 	}))
 	defer ts.Close()
@@ -641,7 +641,7 @@ func TestGetMutes(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-		fmt.Fprintln(w, `[{"Username": "foo"}, {"Username": "bar"}]`)
+		fmt.Fprintln(w, `[{"username": "foo"}, {"username": "bar"}]`)
 		return
 	}))
 	defer ts.Close()

--- a/cmd/mstdn/cmd_upload_test.go
+++ b/cmd/mstdn/cmd_upload_test.go
@@ -14,7 +14,7 @@ func TestCmdUpload(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
 			case "/api/v1/media":
-				fmt.Fprintln(w, `{"ID": 123}`)
+				fmt.Fprintln(w, `{"id": 123}`)
 				return
 			}
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)

--- a/mastodon_test.go
+++ b/mastodon_test.go
@@ -17,7 +17,7 @@ func TestAuthenticate(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 			return
 		}
-		fmt.Fprintln(w, `{"AccessToken": "zoo"}`)
+		fmt.Fprintln(w, `{"access_token": "zoo"}`)
 		return
 	}))
 	defer ts.Close()
@@ -72,7 +72,7 @@ func TestPostStatus(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 			return
 		}
-		fmt.Fprintln(w, `{"AccessToken": "zoo"}`)
+		fmt.Fprintln(w, `{"access_token": "zoo"}`)
 		return
 	}))
 	defer ts.Close()
@@ -130,7 +130,7 @@ func TestPostStatusWithCancel(t *testing.T) {
 
 func TestGetTimelineHome(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `[{"Content": "foo"}, {"Content": "bar"}]`)
+		fmt.Fprintln(w, `[{"content": "foo"}, {"content": "bar"}]`)
 		return
 	}))
 	defer ts.Close()

--- a/status_test.go
+++ b/status_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestGetFavourites(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `[{"Content": "foo"}, {"Content": "bar"}]`)
+		fmt.Fprintln(w, `[{"content": "foo"}, {"content": "bar"}]`)
 		return
 	}))
 	defer ts.Close()
@@ -42,7 +42,7 @@ func TestGetStatus(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
-		fmt.Fprintln(w, `{"Content": "zzz"}`)
+		fmt.Fprintln(w, `{"content": "zzz"}`)
 		return
 	}))
 	defer ts.Close()
@@ -72,7 +72,7 @@ func TestGetStatusCard(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
-		fmt.Fprintln(w, `{"Title": "zzz"}`)
+		fmt.Fprintln(w, `{"title": "zzz"}`)
 		return
 	}))
 	defer ts.Close()
@@ -102,7 +102,7 @@ func TestGetStatusContext(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
-		fmt.Fprintln(w, `{"ancestors": [{"Content": "zzz"},{"Content": "bbb"}]}`)
+		fmt.Fprintln(w, `{"ancestors": [{"content": "zzz"},{"content": "bbb"}]}`)
 		return
 	}))
 	defer ts.Close()
@@ -141,7 +141,7 @@ func TestGetRebloggedBy(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
-		fmt.Fprintln(w, `[{"Username": "foo"}, {"Username": "bar"}]`)
+		fmt.Fprintln(w, `[{"username": "foo"}, {"username": "bar"}]`)
 		return
 	}))
 	defer ts.Close()
@@ -177,7 +177,7 @@ func TestGetFavouritedBy(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
-		fmt.Fprintln(w, `[{"Username": "foo"}, {"Username": "bar"}]`)
+		fmt.Fprintln(w, `[{"username": "foo"}, {"username": "bar"}]`)
 		return
 	}))
 	defer ts.Close()
@@ -213,7 +213,7 @@ func TestReblog(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
-		fmt.Fprintln(w, `{"Content": "zzz"}`)
+		fmt.Fprintln(w, `{"content": "zzz"}`)
 		return
 	}))
 	defer ts.Close()
@@ -243,7 +243,7 @@ func TestUnreblog(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
-		fmt.Fprintln(w, `{"Content": "zzz"}`)
+		fmt.Fprintln(w, `{"content": "zzz"}`)
 		return
 	}))
 	defer ts.Close()
@@ -273,7 +273,7 @@ func TestFavourite(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
-		fmt.Fprintln(w, `{"Content": "zzz"}`)
+		fmt.Fprintln(w, `{"content": "zzz"}`)
 		return
 	}))
 	defer ts.Close()
@@ -303,7 +303,7 @@ func TestUnfavourite(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
-		fmt.Fprintln(w, `{"Content": "zzz"}`)
+		fmt.Fprintln(w, `{"content": "zzz"}`)
 		return
 	}))
 	defer ts.Close()
@@ -333,7 +333,7 @@ func TestGetTimelineHashtag(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
-		fmt.Fprintln(w, `[{"Content": "zzz"},{"Content": "yyy"}]`)
+		fmt.Fprintln(w, `[{"content": "zzz"},{"content": "yyy"}]`)
 		return
 	}))
 	defer ts.Close()
@@ -405,8 +405,8 @@ func TestSearch(t *testing.T) {
 		}
 
 		fmt.Fprintln(w, `
-			{"accounts":[{"Username": "zzz"},{"Username": "yyy"}],
-			"statuses":[{"Content": "aaa"}],
+			{"accounts":[{"username": "zzz"},{"username": "yyy"}],
+			"statuses":[{"content": "aaa"}],
 			"hashtags":["tag","tag2","tag3"]
 		}`)
 		return
@@ -453,7 +453,7 @@ func TestUploadMedia(t *testing.T) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
-		fmt.Fprintln(w, `{"ID": 123}`)
+		fmt.Fprintln(w, `{"id": 123}`)
 		return
 	}))
 	defer ts.Close()

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -18,13 +18,13 @@ func TestStreamingPublic(t *testing.T) {
 		f, _ := w.(http.Flusher)
 		fmt.Fprintln(w, `
 event: update
-data: {"Content": "foo"}
+data: {"content": "foo"}
 		`)
 		f.Flush()
 
 		fmt.Fprintln(w, `
 event: update
-data: {"Content": "bar"}
+data: {"content": "bar"}
 		`)
 		f.Flush()
 		return


### PR DESCRIPTION
In some test cases, PascalCase is used as json property name. However, the actual json data have snake_case property name, and test cases should fail if target struct has no json tag. So I fixed it as follows.

before | after
--- | ---
`AccessToken` | `access_token`
`Content` | `content`
`ID` | `id`
`Title` | `title`
`Username` |  `username`