### PR TITLE
fix client is not set when first use

### DIFF
--- a/cmd/mstdn/main.go
+++ b/cmd/mstdn/main.go
@@ -329,12 +329,12 @@ func run() int {
 		}
 
 		client := mastodon.NewClient(config)
-		if config.AccessToken == "" {
-			return authenticate(client, config, file)
-		}
 		app.Metadata = map[string]interface{}{
 			"client": client,
 			"config": config,
+		}
+		if config.AccessToken == "" {
+			return authenticate(client, config, file)
 		}
 		return nil
 	}


### PR DESCRIPTION
Hello.

cmd/mstdn outputs panic when it is first use after user inputs authenticate information.

```
E-Mail: MYMAIL_ADDRESS@example.com
Password: **********
panic: interface conversion: interface {} is nil, not *mastodon.Client

goroutine 1 [running]:
main.cmdToot(0xc42040dcc0, 0x0, 0xc42040dcc0)
	/home/tsr/gopath/src/github.com/mattn/go-mastodon/cmd/mstdn/cmd_toot.go:27 +0x1fa
github.com/urfave/cli.HandleAction(0x713ac0, 0x794560, 0xc42040dcc0, 0xc420122800, 0x0)
	/home/tsr/gopath/src/github.com/urfave/cli/app.go:485 +0xd4
github.com/urfave/cli.Command.Run(0x77c128, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0x77feff, 0x9, 0x0, ...)
	/home/tsr/gopath/src/github.com/urfave/cli/command.go:207 +0xb72
github.com/urfave/cli.(*App).Run(0xc4200de1a0, 0xc420010270, 0x3, 0x3, 0x0, 0x0)
	/home/tsr/gopath/src/github.com/urfave/cli/app.go:250 +0x7d0
main.run(0xc4200001a0)
	/home/tsr/gopath/src/github.com/mattn/go-mastodon/cmd/mstdn/main.go:342 +0xb3
main.main()
	/home/tsr/gopath/src/github.com/mattn/go-mastodon/cmd/mstdn/main.go:347 +0x22
```