### PR TITLE
Fix error message

### DIFF
--- a/accounts_test.go
+++ b/accounts_test.go
@@ -27,7 +27,7 @@ func TestGetAccount(t *testing.T) {
 	})
 	a, err := client.GetAccount(context.Background(), 1)
 	if err == nil {
-		t.Fatalf("should not be fail: %v", err)
+		t.Fatalf("should be fail: %v", err)
 	}
 	a, err = client.GetAccount(context.Background(), 1234567)
 	if err != nil {

--- a/cmd/mstdn/cmd_follow_test.go
+++ b/cmd/mstdn/cmd_follow_test.go
@@ -60,7 +60,7 @@ func TestCmdFollow(t *testing.T) {
 		func(app *cli.App) {
 			err := app.Run([]string{"mstdn", "follow", "different_id"})
 			if err == nil {
-				t.Fatalf("should not be fail: %v", err)
+				t.Fatalf("should be fail: %v", err)
 			}
 		},
 	)


### PR DESCRIPTION
https://github.com/mattn/go-mastodon/pull/39#discussion_r112883768

> When func return NOT nil for err expected, it should check `if err == nil` and message should be `should be fail`.
