### PR TITLE
Fix to output error log of cmd

### DIFF
--- a/cmd/mstdn/main.go
+++ b/cmd/mstdn/main.go
@@ -339,7 +339,7 @@ func run() int {
 		return nil
 	}
 
-	app.Run(os.Args)
+	fatalIf(app.Run(os.Args))
 	return 0
 }
 


### PR DESCRIPTION
This PR provides error message display function of cmd.

Before:

```console
$ mstdn timeline
$ _ # Quit without displaying anything.
```

After:

```console
$ mstdn timeline
mstdn: bad request: 401 Unauthorized: The access token was revoked
```