### PR TITLE
Fix usage code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,32 @@
 ## Usage
 
 ```go
-c := mastodon.NewClient(&mastodon.Config{
-	Server:       "https://mstdn.jp",
-	ClientID:     "client-id",
-	ClientSecret: "client-secret",
-})
-err := c.Authenticate("your-username", "your-password")
-if err != nil {
-	log.Fatal(err)
-}
-timeline, err := c.GetTimelineHome(context.Background())
-if err != nil {
-	log.Fatal(err)
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/mattn/go-mastodon"
+	"log"
+)
+
+func main() {
+	c := mastodon.NewClient(&mastodon.Config{
+		Server:       "https://mstdn.jp",
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+	})
+	err := c.Authenticate(context.Background(), "your-email", "your-password")
+	if err != nil {
+		log.Fatal(err)
+	}
+	timeline, err := c.GetTimelineHome(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	for i := len(timeline) - 1; i >= 0; i-- {
+		fmt.Println(timeline[i])
+	}
 }
 ```
 ## Status of implementations


### PR DESCRIPTION
Usage code does not work.

Authenticate function has a few arguments. It has not two arguments but three arguments.
It is hard to understand "your-username".  Mastodon account has a username and a email. It is correct to specify an email when authenticating.
timeline variable is not used, so `go build` will fail.

I fixed above.