### PR TITLE
Fix GetTimelineHashtag

### DIFF
--- a/cmd/mstdn/cmd_stream.go
+++ b/cmd/mstdn/cmd_stream.go
@@ -64,13 +64,13 @@ func cmdStream(c *cli.Context) error {
 
 	t := c.String("type")
 	if t == "public" {
-		q, err = client.StreamingPublic(ctx)
+		q, err = client.StreamingPublic(ctx, false)
 	} else if t == "" || t == "public/local" {
-		q, err = client.StreamingPublicLocal(ctx)
+		q, err = client.StreamingPublic(ctx, true)
 	} else if strings.HasPrefix(t, "user:") {
-		q, err = client.StreamingUser(ctx, t[5:])
+		q, err = client.StreamingUser(ctx)
 	} else if strings.HasPrefix(t, "hashtag:") {
-		q, err = client.StreamingHashtag(ctx, t[8:])
+		q, err = client.StreamingHashtag(ctx, t[8:], false)
 	} else {
 		return errors.New("invalid type")
 	}

--- a/status.go
+++ b/status.go
@@ -173,9 +173,14 @@ func (c *Client) GetTimelinePublic(ctx context.Context, isLocal bool) ([]*Status
 }
 
 // GetTimelineHashtag return statuses from tagged timeline.
-func (c *Client) GetTimelineHashtag(ctx context.Context, tag string) ([]*Status, error) {
+func (c *Client) GetTimelineHashtag(ctx context.Context, tag string, isLocal bool) ([]*Status, error) {
+	params := url.Values{}
+	if isLocal {
+		params.Set("local", "t")
+	}
+
 	var statuses []*Status
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/timelines/tag/%s", (&url.URL{Path: tag}).EscapedPath()), nil, &statuses, nil)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/timelines/tag/%s", url.PathEscape(tag)), params, &statuses, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/status_test.go
+++ b/status_test.go
@@ -374,11 +374,11 @@ func TestGetTimelineHashtag(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	_, err := client.GetTimelineHashtag(context.Background(), "notfound")
+	_, err := client.GetTimelineHashtag(context.Background(), "notfound", false)
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	tags, err := client.GetTimelineHashtag(context.Background(), "zzz")
+	tags, err := client.GetTimelineHashtag(context.Background(), "zzz", true)
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -38,7 +38,7 @@ data: {"content": "bar"}
 		AccessToken:  "zoo",
 	})
 	ctx, cancel := context.WithCancel(context.Background())
-	q, err := client.StreamingPublic(ctx)
+	q, err := client.StreamingPublic(ctx, false)
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}

--- a/streaming_ws.go
+++ b/streaming_ws.go
@@ -24,29 +24,29 @@ type Stream struct {
 	Payload interface{} `json:"payload"`
 }
 
-// StreamingWSPublic return channel to read events on public using WebSocket.
-func (c *WSClient) StreamingWSPublic(ctx context.Context) (chan Event, error) {
-	return c.streamingWS(ctx, "public", "")
-}
-
-// StreamingWSPublicLocal return channel to read events on public local using WebSocket.
-func (c *WSClient) StreamingWSPublicLocal(ctx context.Context) (chan Event, error) {
-	return c.streamingWS(ctx, "public:local", "")
-}
-
 // StreamingWSUser return channel to read events on home using WebSocket.
 func (c *WSClient) StreamingWSUser(ctx context.Context) (chan Event, error) {
 	return c.streamingWS(ctx, "user", "")
 }
 
-// StreamingWSHashtag return channel to read events on tagged timeline using WebSocket.
-func (c *WSClient) StreamingWSHashtag(ctx context.Context, tag string) (chan Event, error) {
-	return c.streamingWS(ctx, "hashtag", tag)
+// StreamingWSPublic return channel to read events on public using WebSocket.
+func (c *WSClient) StreamingWSPublic(ctx context.Context, isLocal bool) (chan Event, error) {
+	s := "public"
+	if isLocal {
+		s += ":local"
+	}
+
+	return c.streamingWS(ctx, s, "")
 }
 
-// StreamingWSHashtagLocal return channel to read events on tagged local timeline using WebSocket.
-func (c *WSClient) StreamingWSHashtagLocal(ctx context.Context, tag string) (chan Event, error) {
-	return c.streamingWS(ctx, "hashtag:local", tag)
+// StreamingWSHashtag return channel to read events on tagged timeline using WebSocket.
+func (c *WSClient) StreamingWSHashtag(ctx context.Context, tag string, isLocal bool) (chan Event, error) {
+	s := "hashtag"
+	if isLocal {
+		s += ":local"
+	}
+
+	return c.streamingWS(ctx, s, tag)
 }
 
 func (c *WSClient) streamingWS(ctx context.Context, stream, tag string) (chan Event, error) {

--- a/streaming_ws_test.go
+++ b/streaming_ws_test.go
@@ -16,21 +16,7 @@ func TestStreamingWSPublic(t *testing.T) {
 
 	client := NewClient(&Config{Server: ts.URL}).NewWSClient()
 	ctx, cancel := context.WithCancel(context.Background())
-	q, err := client.StreamingWSPublic(ctx)
-	if err != nil {
-		t.Fatalf("should not be fail: %v", err)
-	}
-
-	wsTest(t, q, cancel)
-}
-
-func TestStreamingWSPublicLocal(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(wsMock))
-	defer ts.Close()
-
-	client := NewClient(&Config{Server: ts.URL}).NewWSClient()
-	ctx, cancel := context.WithCancel(context.Background())
-	q, err := client.StreamingWSPublicLocal(ctx)
+	q, err := client.StreamingWSPublic(ctx, false)
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
@@ -58,21 +44,7 @@ func TestStreamingWSHashtag(t *testing.T) {
 
 	client := NewClient(&Config{Server: ts.URL}).NewWSClient()
 	ctx, cancel := context.WithCancel(context.Background())
-	q, err := client.StreamingWSHashtag(ctx, "zzz")
-	if err != nil {
-		t.Fatalf("should not be fail: %v", err)
-	}
-
-	wsTest(t, q, cancel)
-}
-
-func TestStreamingWSHashtagLocal(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(wsMock))
-	defer ts.Close()
-
-	client := NewClient(&Config{Server: ts.URL}).NewWSClient()
-	ctx, cancel := context.WithCancel(context.Background())
-	q, err := client.StreamingWSHashtagLocal(ctx, "zzz")
+	q, err := client.StreamingWSHashtag(ctx, "zzz", false)
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
@@ -156,7 +128,7 @@ func TestStreamingWS(t *testing.T) {
 	defer ts.Close()
 
 	client := NewClient(&Config{Server: ":"}).NewWSClient()
-	_, err := client.StreamingWSPublicLocal(context.Background())
+	_, err := client.StreamingWSPublic(context.Background(), true)
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
@@ -164,7 +136,7 @@ func TestStreamingWS(t *testing.T) {
 	client = NewClient(&Config{Server: ts.URL}).NewWSClient()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	q, err := client.StreamingWSPublicLocal(ctx)
+	q, err := client.StreamingWSPublic(ctx, true)
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}

--- a/streaming_ws_test.go
+++ b/streaming_ws_test.go
@@ -44,11 +44,17 @@ func TestStreamingWSHashtag(t *testing.T) {
 
 	client := NewClient(&Config{Server: ts.URL}).NewWSClient()
 	ctx, cancel := context.WithCancel(context.Background())
-	q, err := client.StreamingWSHashtag(ctx, "zzz", false)
+	q, err := client.StreamingWSHashtag(ctx, "zzz", true)
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
+	wsTest(t, q, cancel)
 
+	ctx, cancel = context.WithCancel(context.Background())
+	q, err = client.StreamingWSHashtag(ctx, "zzz", false)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
 	wsTest(t, q, cancel)
 }
 
@@ -107,7 +113,7 @@ func wsTest(t *testing.T, q chan Event, cancel func()) {
 		events = append(events, e)
 	}
 	if len(events) != 4 {
-		t.Fatalf("result should be two: %d", len(events))
+		t.Fatalf("result should be four: %d", len(events))
 	}
 	if events[0].(*UpdateEvent).Status.Content != "foo" {
 		t.Fatalf("want %q but %q", "foo", events[0].(*UpdateEvent).Status.Content)


### PR DESCRIPTION
* Add argument to return hashtag of local timeline.
* Fix bug that slash can not be escaped and it becomes HTTP status 404.
https://play.golang.org/p/YbZqgb7sYK