### PR TITLE
Optimize streaming

### DIFF
--- a/cmd/mstdn/cmd_stream.go
+++ b/cmd/mstdn/cmd_stream.go
@@ -80,7 +80,6 @@ func cmdStream(c *cli.Context) error {
 	go func() {
 		<-sc
 		cancel()
-		close(q)
 	}()
 
 	c.App.Metadata["signal"] = sc

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -14,6 +14,8 @@ func TestHandleReader(t *testing.T) {
 	q := make(chan Event)
 	r := strings.NewReader(`
 event: update
+data: {content: error}
+event: update
 data: {"content": "foo"}
 event: notification
 data: {"type": "mention"}
@@ -28,7 +30,7 @@ data: 1234567
 			t.Fatalf("should not be fail: %v", err)
 		}
 	}()
-	var passUpdate, passNotification, passDelete bool
+	var passUpdate, passNotification, passDelete, passError bool
 	for e := range q {
 		switch event := e.(type) {
 		case *UpdateEvent:
@@ -46,11 +48,17 @@ data: 1234567
 			if event.ID != 1234567 {
 				t.Fatalf("want %d but %d", 1234567, event.ID)
 			}
+		case *ErrorEvent:
+			passError = true
+			if event.err == nil {
+				t.Fatalf("should be fail: %v", event.err)
+			}
 		}
 	}
-	if !passUpdate || !passNotification || !passDelete {
-		t.Fatalf("have not passed through somewhere: update %t, notification %t, delete %t",
-			passUpdate, passNotification, passDelete)
+	if !passUpdate || !passNotification || !passDelete || !passError {
+		t.Fatalf("have not passed through somewhere: "+
+			"update %t, notification %t, delete %t, error %t",
+			passUpdate, passNotification, passDelete, passError)
 	}
 }
 

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -165,6 +165,9 @@ func TestStreamingUser(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isEnd {
 			return
+		} else if r.URL.Path != "/api/v1/streaming/user" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
 		}
 		f, _ := w.(http.Flusher)
 		fmt.Fprintln(w, `
@@ -202,7 +205,7 @@ func TestStreamingPublic(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isEnd {
 			return
-		} else if r.URL.Path != "/api/v1/streaming/public" {
+		} else if r.URL.Path != "/api/v1/streaming/public/local" {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
@@ -229,7 +232,7 @@ data: {"content": "bar"}
 		AccessToken:  "zoo",
 	})
 	ctx, cancel := context.WithCancel(context.Background())
-	q, err := client.StreamingPublic(ctx, false)
+	q, err := client.StreamingPublic(ctx, true)
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
@@ -252,4 +255,41 @@ data: {"content": "bar"}
 }
 
 func TestStreamingHashtag(t *testing.T) {
+	var isEnd bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isEnd {
+			return
+		} else if r.URL.Path != "/api/v1/streaming/hashtag/local" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		f, _ := w.(http.Flusher)
+		fmt.Fprintln(w, `
+event: update
+data: {"content": "foo"}
+		`)
+		f.Flush()
+		isEnd = true
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{Server: ts.URL})
+	ctx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(time.Second, cancel)
+	q, err := client.StreamingHashtag(ctx, "hashtag", true)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	events := []Event{}
+	for e := range q {
+		if _, ok := e.(*ErrorEvent); !ok {
+			events = append(events, e)
+		}
+	}
+	if len(events) != 1 {
+		t.Fatalf("result should be one: %d", len(events))
+	}
+	if events[0].(*UpdateEvent).Status.Content != "foo" {
+		t.Fatalf("want %q but %q", "foo", events[0].(*UpdateEvent).Status.Content)
+	}
 }


### PR DESCRIPTION
This PR provides streaming optimization and testing.

* Send parse error of data to the event channel.
* Divided the function to close Body using `defer`.
* Fix parsing of data of delete event to ParseInt to speed up parsing.

Benchmark of parse:

```go
func BenchmarkAtoi(b *testing.B) {
	s := " 1234567"
	for i := 0; i < b.N; i++ {
		i, err := strconv.Atoi(strings.TrimSpace(s))
		_ = int64(i)
		if err != nil {
			b.Fatal(err)
		}
	}
}

func BenchmarkParseInt(b *testing.B) {
	s := " 1234567"
	for i := 0; i < b.N; i++ {
		_, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
		if err != nil {
			b.Fatal(err)
		}
	}
}

func BenchmarkUnmarshal(b *testing.B) {
	s := " 1234567"
	for i := 0; i < b.N; i++ {
		var i int64
		err := json.Unmarshal([]byte(s), &i)
		if err != nil {
			b.Fatal(err)
		}
	}
}
```

```
BenchmarkAtoi-8        	30000000	        52.6 ns/op
BenchmarkParseInt-8    	30000000	        48.0 ns/op
BenchmarkUnmarshal-8   	 3000000	       445 ns/op
```