### PR TITLE
Fix close of streaming WebSocket

### DIFF
--- a/streaming_ws_test.go
+++ b/streaming_ws_test.go
@@ -10,20 +10,6 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-func TestStreamingWSPublic(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(wsMock))
-	defer ts.Close()
-
-	client := NewClient(&Config{Server: ts.URL}).NewWSClient()
-	ctx, cancel := context.WithCancel(context.Background())
-	q, err := client.StreamingWSPublic(ctx, false)
-	if err != nil {
-		t.Fatalf("should not be fail: %v", err)
-	}
-
-	wsTest(t, q, cancel)
-}
-
 func TestStreamingWSUser(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(wsMock))
 	defer ts.Close()
@@ -31,6 +17,20 @@ func TestStreamingWSUser(t *testing.T) {
 	client := NewClient(&Config{Server: ts.URL}).NewWSClient()
 	ctx, cancel := context.WithCancel(context.Background())
 	q, err := client.StreamingWSUser(ctx)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+
+	wsTest(t, q, cancel)
+}
+
+func TestStreamingWSPublic(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(wsMock))
+	defer ts.Close()
+
+	client := NewClient(&Config{Server: ts.URL}).NewWSClient()
+	ctx, cancel := context.WithCancel(context.Background())
+	q, err := client.StreamingWSPublic(ctx, false)
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}

--- a/streaming_ws_test.go
+++ b/streaming_ws_test.go
@@ -106,13 +106,12 @@ func wsMock(w http.ResponseWriter, r *http.Request) {
 func wsTest(t *testing.T, q chan Event, cancel func()) {
 	time.AfterFunc(time.Second, func() {
 		cancel()
-		close(q)
 	})
 	events := []Event{}
 	for e := range q {
 		events = append(events, e)
 	}
-	if len(events) != 4 {
+	if len(events) != 6 {
 		t.Fatalf("result should be four: %d", len(events))
 	}
 	if events[0].(*UpdateEvent).Status.Content != "foo" {
@@ -125,6 +124,12 @@ func wsTest(t *testing.T, q chan Event, cancel func()) {
 		t.Fatalf("want %d but %d", 1234567, events[2].(*DeleteEvent).ID)
 	}
 	if errorEvent, ok := events[3].(*ErrorEvent); !ok {
+		t.Fatalf("should be fail: %v", errorEvent.err)
+	}
+	if errorEvent, ok := events[4].(*ErrorEvent); !ok {
+		t.Fatalf("should be fail: %v", errorEvent.err)
+	}
+	if errorEvent, ok := events[5].(*ErrorEvent); !ok {
 		t.Fatalf("should be fail: %v", errorEvent.err)
 	}
 }


### PR DESCRIPTION
Close the WebSocket when the context is canceled.
Also adjusted the order of test to `streaming_ws.go`.