### PR TITLE
Fix not to return error event of context in streaming

### DIFF
--- a/cmd/mstdn/cmd_stream.go
+++ b/cmd/mstdn/cmd_stream.go
@@ -79,7 +79,6 @@ func cmdStream(c *cli.Context) error {
 	}
 	go func() {
 		<-sc
-		close(q)
 		cancel()
 	}()
 

--- a/streaming.go
+++ b/streaming.go
@@ -105,7 +105,6 @@ func (c *Client) streaming(ctx context.Context, p string, params url.Values) (ch
 		for {
 			select {
 			case <-ctx.Done():
-				q <- &ErrorEvent{ctx.Err()}
 				return
 			default:
 			}


### PR DESCRIPTION
There was an error in the test.

```console
$ go test ./...
ok  	github.com/mattn/go-mastodon	9.054s
panic: send on closed channel
	panic: close of closed channel

goroutine 116 [running]:
github.com/mattn/go-mastodon.(*Client).doStreaming(0xc420132d00, 0xc420156a00, 0xc420161500)
	/Users/i178inaba/work/go/src/github.com/mattn/go-mastodon/streaming.go:122 +0xea
github.com/mattn/go-mastodon.(*Client).streaming.func1(0xc420161500, 0x1664f00, 0xc420133240, 0xc420132d00, 0xc420156a00)
	/Users/i178inaba/work/go/src/github.com/mattn/go-mastodon/streaming.go:113 +0xad
created by github.com/mattn/go-mastodon.(*Client).streaming
	/Users/i178inaba/work/go/src/github.com/mattn/go-mastodon/streaming.go:115 +0x2e7
FAIL	github.com/mattn/go-mastodon/cmd/mstdn	5.022s
```

It seemed to be due to the following commit.

> [close q because cancel may be called twice](https://github.com/mattn/go-mastodon/commit/a0466b7cc41809f2e459ce48b07ee702a298bef5)

As indicated by the commit comment, `context canceled` is displayed twice.

```console
$ mstdn stream
xxx@xxx.xx
foobar
^Ccontext canceled
context canceled
```

This seems to have happened when I fixed the streaming API.
`context canceled` is now displayed only once on this fix.

```context
$ mstdn stream
xxx@xxx.xx
foobar
^Ccontext canceled
```

The test was also OK.