### PR TITLE
Remove needless slash

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -30,7 +30,7 @@ type Account struct {
 // GetAccount return Account.
 func (c *Client) GetAccount(ctx context.Context, id int) (*Account, error) {
 	var account Account
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/accounts/%d", id), nil, &account, nil)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("api/v1/accounts/%d", id), nil, &account, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func (c *Client) GetAccount(ctx context.Context, id int) (*Account, error) {
 // GetAccountCurrentUser return Account of current user.
 func (c *Client) GetAccountCurrentUser(ctx context.Context) (*Account, error) {
 	var account Account
-	err := c.doAPI(ctx, http.MethodGet, "/api/v1/accounts/verify_credentials", nil, &account, nil)
+	err := c.doAPI(ctx, http.MethodGet, "api/v1/accounts/verify_credentials", nil, &account, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func (c *Client) AccountUpdate(ctx context.Context, profile *Profile) (*Account,
 	}
 
 	var account Account
-	err := c.doAPI(ctx, http.MethodPatch, "/api/v1/accounts/update_credentials", params, &account, nil)
+	err := c.doAPI(ctx, http.MethodPatch, "api/v1/accounts/update_credentials", params, &account, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (c *Client) AccountUpdate(ctx context.Context, profile *Profile) (*Account,
 // GetAccountStatuses return statuses by specified accuont.
 func (c *Client) GetAccountStatuses(ctx context.Context, id int64, pg *Pagination) ([]*Status, error) {
 	var statuses []*Status
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/accounts/%d/statuses", id), nil, &statuses, pg)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("api/v1/accounts/%d/statuses", id), nil, &statuses, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func (c *Client) GetAccountStatuses(ctx context.Context, id int64, pg *Paginatio
 // GetAccountFollowers return followers list.
 func (c *Client) GetAccountFollowers(ctx context.Context, id int64, pg *Pagination) ([]*Account, error) {
 	var accounts []*Account
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/accounts/%d/followers", id), nil, &accounts, pg)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("api/v1/accounts/%d/followers", id), nil, &accounts, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (c *Client) GetAccountFollowers(ctx context.Context, id int64, pg *Paginati
 // GetAccountFollowing return following list.
 func (c *Client) GetAccountFollowing(ctx context.Context, id int64, pg *Pagination) ([]*Account, error) {
 	var accounts []*Account
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/accounts/%d/following", id), nil, &accounts, pg)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("api/v1/accounts/%d/following", id), nil, &accounts, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (c *Client) GetAccountFollowing(ctx context.Context, id int64, pg *Paginati
 // GetBlocks return block list.
 func (c *Client) GetBlocks(ctx context.Context, pg *Pagination) ([]*Account, error) {
 	var accounts []*Account
-	err := c.doAPI(ctx, http.MethodGet, "/api/v1/blocks", nil, &accounts, pg)
+	err := c.doAPI(ctx, http.MethodGet, "api/v1/blocks", nil, &accounts, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ type Relationship struct {
 // AccountFollow follow the account.
 func (c *Client) AccountFollow(ctx context.Context, id int64) (*Relationship, error) {
 	var relationship Relationship
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%d/follow", id), nil, &relationship, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("api/v1/accounts/%d/follow", id), nil, &relationship, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func (c *Client) AccountFollow(ctx context.Context, id int64) (*Relationship, er
 // AccountUnfollow unfollow the account.
 func (c *Client) AccountUnfollow(ctx context.Context, id int64) (*Relationship, error) {
 	var relationship Relationship
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%d/unfollow", id), nil, &relationship, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("api/v1/accounts/%d/unfollow", id), nil, &relationship, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (c *Client) AccountUnfollow(ctx context.Context, id int64) (*Relationship, 
 // AccountBlock block the account.
 func (c *Client) AccountBlock(ctx context.Context, id int64) (*Relationship, error) {
 	var relationship Relationship
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%d/block", id), nil, &relationship, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("api/v1/accounts/%d/block", id), nil, &relationship, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func (c *Client) AccountBlock(ctx context.Context, id int64) (*Relationship, err
 // AccountUnblock unblock the account.
 func (c *Client) AccountUnblock(ctx context.Context, id int64) (*Relationship, error) {
 	var relationship Relationship
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%d/unblock", id), nil, &relationship, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("api/v1/accounts/%d/unblock", id), nil, &relationship, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +176,7 @@ func (c *Client) AccountUnblock(ctx context.Context, id int64) (*Relationship, e
 // AccountMute mute the account.
 func (c *Client) AccountMute(ctx context.Context, id int64) (*Relationship, error) {
 	var relationship Relationship
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%d/mute", id), nil, &relationship, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("api/v1/accounts/%d/mute", id), nil, &relationship, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (c *Client) AccountMute(ctx context.Context, id int64) (*Relationship, erro
 // AccountUnmute unmute the account.
 func (c *Client) AccountUnmute(ctx context.Context, id int64) (*Relationship, error) {
 	var relationship Relationship
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%d/unmute", id), nil, &relationship, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("api/v1/accounts/%d/unmute", id), nil, &relationship, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func (c *Client) GetAccountRelationships(ctx context.Context, ids []int64) ([]*R
 	}
 
 	var relationships []*Relationship
-	err := c.doAPI(ctx, http.MethodGet, "/api/v1/accounts/relationships", params, &relationships, nil)
+	err := c.doAPI(ctx, http.MethodGet, "api/v1/accounts/relationships", params, &relationships, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +215,7 @@ func (c *Client) AccountsSearch(ctx context.Context, q string, limit int64) ([]*
 	params.Set("limit", fmt.Sprint(limit))
 
 	var accounts []*Account
-	err := c.doAPI(ctx, http.MethodGet, "/api/v1/accounts/search", params, &accounts, nil)
+	err := c.doAPI(ctx, http.MethodGet, "api/v1/accounts/search", params, &accounts, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (c *Client) FollowRemoteUser(ctx context.Context, uri string) (*Account, er
 	params.Set("uri", uri)
 
 	var account Account
-	err := c.doAPI(ctx, http.MethodPost, "/api/v1/follows", params, &account, nil)
+	err := c.doAPI(ctx, http.MethodPost, "api/v1/follows", params, &account, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +238,7 @@ func (c *Client) FollowRemoteUser(ctx context.Context, uri string) (*Account, er
 // GetFollowRequests return follow-requests.
 func (c *Client) GetFollowRequests(ctx context.Context, pg *Pagination) ([]*Account, error) {
 	var accounts []*Account
-	err := c.doAPI(ctx, http.MethodGet, "/api/v1/follow_requests", nil, &accounts, pg)
+	err := c.doAPI(ctx, http.MethodGet, "api/v1/follow_requests", nil, &accounts, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -247,18 +247,18 @@ func (c *Client) GetFollowRequests(ctx context.Context, pg *Pagination) ([]*Acco
 
 // FollowRequestAuthorize is authorize the follow request of user with id.
 func (c *Client) FollowRequestAuthorize(ctx context.Context, id int64) error {
-	return c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/follow_requests/%d/authorize", id), nil, nil, nil)
+	return c.doAPI(ctx, http.MethodPost, fmt.Sprintf("api/v1/follow_requests/%d/authorize", id), nil, nil, nil)
 }
 
 // FollowRequestReject is rejects the follow request of user with id.
 func (c *Client) FollowRequestReject(ctx context.Context, id int64) error {
-	return c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/follow_requests/%d/reject", id), nil, nil, nil)
+	return c.doAPI(ctx, http.MethodPost, fmt.Sprintf("api/v1/follow_requests/%d/reject", id), nil, nil, nil)
 }
 
 // GetMutes returns the list of users muted by the current user.
 func (c *Client) GetMutes(ctx context.Context, pg *Pagination) ([]*Account, error) {
 	var accounts []*Account
-	err := c.doAPI(ctx, http.MethodGet, "/api/v1/mutes", nil, &accounts, pg)
+	err := c.doAPI(ctx, http.MethodGet, "api/v1/mutes", nil, &accounts, pg)
 	if err != nil {
 		return nil, err
 	}

--- a/apps.go
+++ b/apps.go
@@ -49,7 +49,7 @@ func RegisterApp(ctx context.Context, appConfig *AppConfig) (*Application, error
 	if err != nil {
 		return nil, err
 	}
-	u.Path = path.Join(u.Path, "/api/v1/apps")
+	u.Path = path.Join(u.Path, "api/v1/apps")
 
 	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(params.Encode()))
 	if err != nil {

--- a/instance.go
+++ b/instance.go
@@ -16,7 +16,7 @@ type Instance struct {
 // GetInstance return Instance.
 func (c *Client) GetInstance(ctx context.Context) (*Instance, error) {
 	var instance Instance
-	err := c.doAPI(ctx, http.MethodGet, "/api/v1/instance", nil, &instance, nil)
+	err := c.doAPI(ctx, http.MethodGet, "api/v1/instance", nil, &instance, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/notification.go
+++ b/notification.go
@@ -19,7 +19,7 @@ type Notification struct {
 // GetNotifications return notifications.
 func (c *Client) GetNotifications(ctx context.Context, pg *Pagination) ([]*Notification, error) {
 	var notifications []*Notification
-	err := c.doAPI(ctx, http.MethodGet, "/api/v1/notifications", nil, &notifications, pg)
+	err := c.doAPI(ctx, http.MethodGet, "api/v1/notifications", nil, &notifications, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +29,7 @@ func (c *Client) GetNotifications(ctx context.Context, pg *Pagination) ([]*Notif
 // GetNotification return notification.
 func (c *Client) GetNotification(ctx context.Context, id int64) (*Notification, error) {
 	var notification Notification
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/notifications/%d", id), nil, &notification, nil)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("api/v1/notifications/%d", id), nil, &notification, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -38,5 +38,5 @@ func (c *Client) GetNotification(ctx context.Context, id int64) (*Notification, 
 
 // ClearNotifications clear notifications.
 func (c *Client) ClearNotifications(ctx context.Context) error {
-	return c.doAPI(ctx, http.MethodPost, "/api/v1/notifications/clear", nil, nil, nil)
+	return c.doAPI(ctx, http.MethodPost, "api/v1/notifications/clear", nil, nil, nil)
 }

--- a/report.go
+++ b/report.go
@@ -16,7 +16,7 @@ type Report struct {
 // GetReports return report of the current user.
 func (c *Client) GetReports(ctx context.Context) ([]*Report, error) {
 	var reports []*Report
-	err := c.doAPI(ctx, http.MethodGet, "/api/v1/reports", nil, &reports, nil)
+	err := c.doAPI(ctx, http.MethodGet, "api/v1/reports", nil, &reports, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +32,7 @@ func (c *Client) Report(ctx context.Context, accountID int64, ids []int64, comme
 	}
 	params.Set("comment", comment)
 	var report Report
-	err := c.doAPI(ctx, http.MethodPost, "/api/v1/reports", params, &report, nil)
+	err := c.doAPI(ctx, http.MethodPost, "api/v1/reports", params, &report, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/status.go
+++ b/status.go
@@ -50,7 +50,7 @@ type Card struct {
 // GetFavourites return the favorite list of the current user.
 func (c *Client) GetFavourites(ctx context.Context, pg *Pagination) ([]*Status, error) {
 	var statuses []*Status
-	err := c.doAPI(ctx, http.MethodGet, "/api/v1/favourites", nil, &statuses, pg)
+	err := c.doAPI(ctx, http.MethodGet, "api/v1/favourites", nil, &statuses, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (c *Client) GetFavourites(ctx context.Context, pg *Pagination) ([]*Status, 
 // GetStatus return status specified by id.
 func (c *Client) GetStatus(ctx context.Context, id int64) (*Status, error) {
 	var status Status
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/statuses/%d", id), nil, &status, nil)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("api/v1/statuses/%d", id), nil, &status, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (c *Client) GetStatus(ctx context.Context, id int64) (*Status, error) {
 // GetStatusContext return status specified by id.
 func (c *Client) GetStatusContext(ctx context.Context, id int64) (*Context, error) {
 	var context Context
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/statuses/%d/context", id), nil, &context, nil)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("api/v1/statuses/%d/context", id), nil, &context, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (c *Client) GetStatusContext(ctx context.Context, id int64) (*Context, erro
 // GetStatusCard return status specified by id.
 func (c *Client) GetStatusCard(ctx context.Context, id int64) (*Card, error) {
 	var card Card
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/statuses/%d/card", id), nil, &card, nil)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("api/v1/statuses/%d/card", id), nil, &card, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (c *Client) GetStatusCard(ctx context.Context, id int64) (*Card, error) {
 // GetRebloggedBy returns the account list of the user who reblogged the toot of id.
 func (c *Client) GetRebloggedBy(ctx context.Context, id int64, pg *Pagination) ([]*Account, error) {
 	var accounts []*Account
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/statuses/%d/reblogged_by", id), nil, &accounts, pg)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("api/v1/statuses/%d/reblogged_by", id), nil, &accounts, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func (c *Client) GetRebloggedBy(ctx context.Context, id int64, pg *Pagination) (
 // GetFavouritedBy returns the account list of the user who liked the toot of id.
 func (c *Client) GetFavouritedBy(ctx context.Context, id int64, pg *Pagination) ([]*Account, error) {
 	var accounts []*Account
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/statuses/%d/favourited_by", id), nil, &accounts, pg)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("api/v1/statuses/%d/favourited_by", id), nil, &accounts, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (c *Client) GetFavouritedBy(ctx context.Context, id int64, pg *Pagination) 
 // Reblog is reblog the toot of id and return status of reblog.
 func (c *Client) Reblog(ctx context.Context, id int64) (*Status, error) {
 	var status Status
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/statuses/%d/reblog", id), nil, &status, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("api/v1/statuses/%d/reblog", id), nil, &status, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (c *Client) Reblog(ctx context.Context, id int64) (*Status, error) {
 // Unreblog is unreblog the toot of id and return status of the original toot.
 func (c *Client) Unreblog(ctx context.Context, id int64) (*Status, error) {
 	var status Status
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/statuses/%d/unreblog", id), nil, &status, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("api/v1/statuses/%d/unreblog", id), nil, &status, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (c *Client) Unreblog(ctx context.Context, id int64) (*Status, error) {
 // Favourite is favourite the toot of id and return status of the favourite toot.
 func (c *Client) Favourite(ctx context.Context, id int64) (*Status, error) {
 	var status Status
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/statuses/%d/favourite", id), nil, &status, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("api/v1/statuses/%d/favourite", id), nil, &status, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (c *Client) Favourite(ctx context.Context, id int64) (*Status, error) {
 // Unfavourite is unfavourite the toot of id and return status of the unfavourite toot.
 func (c *Client) Unfavourite(ctx context.Context, id int64) (*Status, error) {
 	var status Status
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/statuses/%d/unfavourite", id), nil, &status, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("api/v1/statuses/%d/unfavourite", id), nil, &status, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func (c *Client) Unfavourite(ctx context.Context, id int64) (*Status, error) {
 // GetTimelineHome return statuses from home timeline.
 func (c *Client) GetTimelineHome(ctx context.Context, pg *Pagination) ([]*Status, error) {
 	var statuses []*Status
-	err := c.doAPI(ctx, http.MethodGet, "/api/v1/timelines/home", nil, &statuses, pg)
+	err := c.doAPI(ctx, http.MethodGet, "api/v1/timelines/home", nil, &statuses, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (c *Client) GetTimelinePublic(ctx context.Context, isLocal bool, pg *Pagina
 	}
 
 	var statuses []*Status
-	err := c.doAPI(ctx, http.MethodGet, "/api/v1/timelines/public", params, &statuses, pg)
+	err := c.doAPI(ctx, http.MethodGet, "api/v1/timelines/public", params, &statuses, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (c *Client) GetTimelineHashtag(ctx context.Context, tag string, isLocal boo
 	}
 
 	var statuses []*Status
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/timelines/tag/%s", url.PathEscape(tag)), params, &statuses, pg)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("api/v1/timelines/tag/%s", url.PathEscape(tag)), params, &statuses, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func (c *Client) GetTimelineMedia(ctx context.Context, isLocal bool, pg *Paginat
 	}
 
 	var statuses []*Status
-	err := c.doAPI(ctx, http.MethodGet, "/api/v1/timelines/public", params, &statuses, pg)
+	err := c.doAPI(ctx, http.MethodGet, "api/v1/timelines/public", params, &statuses, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func (c *Client) PostStatus(ctx context.Context, toot *Toot) (*Status, error) {
 	}
 
 	var status Status
-	err := c.doAPI(ctx, http.MethodPost, "/api/v1/statuses", params, &status, nil)
+	err := c.doAPI(ctx, http.MethodPost, "api/v1/statuses", params, &status, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +236,7 @@ func (c *Client) PostStatus(ctx context.Context, toot *Toot) (*Status, error) {
 
 // DeleteStatus delete the toot.
 func (c *Client) DeleteStatus(ctx context.Context, id int64) error {
-	return c.doAPI(ctx, http.MethodDelete, fmt.Sprintf("/api/v1/statuses/%d", id), nil, nil, nil)
+	return c.doAPI(ctx, http.MethodDelete, fmt.Sprintf("api/v1/statuses/%d", id), nil, nil, nil)
 }
 
 // Search search content with query.
@@ -245,7 +245,7 @@ func (c *Client) Search(ctx context.Context, q string, resolve bool) (*Results, 
 	params.Set("q", q)
 	params.Set("resolve", fmt.Sprint(resolve))
 	var results Results
-	err := c.doAPI(ctx, http.MethodGet, "/api/v1/search", params, &results, nil)
+	err := c.doAPI(ctx, http.MethodGet, "api/v1/search", params, &results, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +255,7 @@ func (c *Client) Search(ctx context.Context, q string, resolve bool) (*Results, 
 // UploadMedia upload a media attachment.
 func (c *Client) UploadMedia(ctx context.Context, file string) (*Attachment, error) {
 	var attachment Attachment
-	err := c.doAPI(ctx, http.MethodPost, "/api/v1/media", file, &attachment, nil)
+	err := c.doAPI(ctx, http.MethodPost, "api/v1/media", file, &attachment, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/streaming.go
+++ b/streaming.go
@@ -89,7 +89,7 @@ func (c *Client) streaming(ctx context.Context, p string, params url.Values) (ch
 	if err != nil {
 		return nil, err
 	}
-	u.Path = path.Join(u.Path, "/api/v1/streaming", p)
+	u.Path = path.Join(u.Path, "api/v1/streaming", p)
 	u.RawQuery = params.Encode()
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)

--- a/streaming_ws.go
+++ b/streaming_ws.go
@@ -61,7 +61,7 @@ func (c *WSClient) streamingWS(ctx context.Context, stream, tag string) (chan Ev
 	if err != nil {
 		return nil, err
 	}
-	u.Path = path.Join(u.Path, "/api/v1/streaming")
+	u.Path = path.Join(u.Path, "api/v1/streaming")
 	u.RawQuery = params.Encode()
 
 	q := make(chan Event)


### PR DESCRIPTION
Since the path of URL is properly connected using Join, the slash is unnecessary.

The command used for edited is below.

```console
$ find . -name '*.go' ! -name '*test*' | LC_ALL=C xargs sed -i '' 's|/api|api|g'
```