### PR TITLE
Add package documents

### DIFF
--- a/mastodon.go
+++ b/mastodon.go
@@ -1,3 +1,4 @@
+// Package mastodon provides functions and structs for accessing the mastodon API.
 package mastodon
 
 import (


### PR DESCRIPTION
There is a warning with lint of godoc.
https://godoc.org/github.com/mattn/go-mastodon?tools

Add a document and clear the warning.