### PR TITLE
Change api specification.

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -10,7 +10,7 @@ import (
 
 // Account hold information for mastodon account.
 type Account struct {
-	ID             int64     `json:"id"`
+	ID             string    `json:"id"`
 	Username       string    `json:"username"`
 	Acct           string    `json:"acct"`
 	DisplayName    string    `json:"display_name"`

--- a/status.go
+++ b/status.go
@@ -11,7 +11,7 @@ import (
 
 // Status is struct to hold status.
 type Status struct {
-	ID                 int64        `json:"id"`
+	ID                 string       `json:"id"`
 	CreatedAt          time.Time    `json:"created_at"`
 	InReplyToID        interface{}  `json:"in_reply_to_id"`
 	InReplyToAccountID interface{}  `json:"in_reply_to_account_id"`


### PR DESCRIPTION
From mastodon 2.0, ID field of json is double quoted.