### PR TITLE
Fix type of IDs.

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -10,7 +10,7 @@ import (
 
 // Account hold information for mastodon account.
 type Account struct {
-	ID             int64     `json:"id"`
+	ID             ID        `json:"id"`
 	Username       string    `json:"username"`
 	Acct           string    `json:"acct"`
 	DisplayName    string    `json:"display_name"`
@@ -28,9 +28,9 @@ type Account struct {
 }
 
 // GetAccount return Account.
-func (c *Client) GetAccount(ctx context.Context, id int) (*Account, error) {
+func (c *Client) GetAccount(ctx context.Context, id ID) (*Account, error) {
 	var account Account
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/accounts/%d", id), nil, &account, nil)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/accounts/%s", url.PathEscape(string(id))), nil, &account, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -84,9 +84,9 @@ func (c *Client) AccountUpdate(ctx context.Context, profile *Profile) (*Account,
 }
 
 // GetAccountStatuses return statuses by specified accuont.
-func (c *Client) GetAccountStatuses(ctx context.Context, id int64, pg *Pagination) ([]*Status, error) {
+func (c *Client) GetAccountStatuses(ctx context.Context, id ID, pg *Pagination) ([]*Status, error) {
 	var statuses []*Status
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/accounts/%d/statuses", id), nil, &statuses, pg)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/accounts/%s/statuses", url.PathEscape(string(id))), nil, &statuses, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -94,9 +94,9 @@ func (c *Client) GetAccountStatuses(ctx context.Context, id int64, pg *Paginatio
 }
 
 // GetAccountFollowers return followers list.
-func (c *Client) GetAccountFollowers(ctx context.Context, id int64, pg *Pagination) ([]*Account, error) {
+func (c *Client) GetAccountFollowers(ctx context.Context, id ID, pg *Pagination) ([]*Account, error) {
 	var accounts []*Account
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/accounts/%d/followers", id), nil, &accounts, pg)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/accounts/%s/followers", url.PathEscape(string(id))), nil, &accounts, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -104,9 +104,9 @@ func (c *Client) GetAccountFollowers(ctx context.Context, id int64, pg *Paginati
 }
 
 // GetAccountFollowing return following list.
-func (c *Client) GetAccountFollowing(ctx context.Context, id int64, pg *Pagination) ([]*Account, error) {
+func (c *Client) GetAccountFollowing(ctx context.Context, id ID, pg *Pagination) ([]*Account, error) {
 	var accounts []*Account
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/accounts/%d/following", id), nil, &accounts, pg)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/accounts/%s/following", url.PathEscape(string(id))), nil, &accounts, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -125,18 +125,18 @@ func (c *Client) GetBlocks(ctx context.Context, pg *Pagination) ([]*Account, err
 
 // Relationship hold information for relation-ship to the account.
 type Relationship struct {
-	ID         int64 `json:"id"`
-	Following  bool  `json:"following"`
-	FollowedBy bool  `json:"followed_by"`
-	Blocking   bool  `json:"blocking"`
-	Muting     bool  `json:"muting"`
-	Requested  bool  `json:"requested"`
+	ID         ID   `json:"id"`
+	Following  bool `json:"following"`
+	FollowedBy bool `json:"followed_by"`
+	Blocking   bool `json:"blocking"`
+	Muting     bool `json:"muting"`
+	Requested  bool `json:"requested"`
 }
 
 // AccountFollow follow the account.
-func (c *Client) AccountFollow(ctx context.Context, id int64) (*Relationship, error) {
+func (c *Client) AccountFollow(ctx context.Context, id ID) (*Relationship, error) {
 	var relationship Relationship
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%d/follow", id), nil, &relationship, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%s/follow", url.PathEscape(string(id))), nil, &relationship, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -144,9 +144,9 @@ func (c *Client) AccountFollow(ctx context.Context, id int64) (*Relationship, er
 }
 
 // AccountUnfollow unfollow the account.
-func (c *Client) AccountUnfollow(ctx context.Context, id int64) (*Relationship, error) {
+func (c *Client) AccountUnfollow(ctx context.Context, id ID) (*Relationship, error) {
 	var relationship Relationship
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%d/unfollow", id), nil, &relationship, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%s/unfollow", url.PathEscape(string(id))), nil, &relationship, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -154,9 +154,9 @@ func (c *Client) AccountUnfollow(ctx context.Context, id int64) (*Relationship, 
 }
 
 // AccountBlock block the account.
-func (c *Client) AccountBlock(ctx context.Context, id int64) (*Relationship, error) {
+func (c *Client) AccountBlock(ctx context.Context, id ID) (*Relationship, error) {
 	var relationship Relationship
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%d/block", id), nil, &relationship, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%s/block", url.PathEscape(string(id))), nil, &relationship, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -164,9 +164,9 @@ func (c *Client) AccountBlock(ctx context.Context, id int64) (*Relationship, err
 }
 
 // AccountUnblock unblock the account.
-func (c *Client) AccountUnblock(ctx context.Context, id int64) (*Relationship, error) {
+func (c *Client) AccountUnblock(ctx context.Context, id ID) (*Relationship, error) {
 	var relationship Relationship
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%d/unblock", id), nil, &relationship, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%s/unblock", url.PathEscape(string(id))), nil, &relationship, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -174,9 +174,9 @@ func (c *Client) AccountUnblock(ctx context.Context, id int64) (*Relationship, e
 }
 
 // AccountMute mute the account.
-func (c *Client) AccountMute(ctx context.Context, id int64) (*Relationship, error) {
+func (c *Client) AccountMute(ctx context.Context, id ID) (*Relationship, error) {
 	var relationship Relationship
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%d/mute", id), nil, &relationship, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%s/mute", url.PathEscape(string(id))), nil, &relationship, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -184,9 +184,9 @@ func (c *Client) AccountMute(ctx context.Context, id int64) (*Relationship, erro
 }
 
 // AccountUnmute unmute the account.
-func (c *Client) AccountUnmute(ctx context.Context, id int64) (*Relationship, error) {
+func (c *Client) AccountUnmute(ctx context.Context, id ID) (*Relationship, error) {
 	var relationship Relationship
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%d/unmute", id), nil, &relationship, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/accounts/%s/unmute", url.PathEscape(string(id))), nil, &relationship, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -194,10 +194,10 @@ func (c *Client) AccountUnmute(ctx context.Context, id int64) (*Relationship, er
 }
 
 // GetAccountRelationships return relationship for the account.
-func (c *Client) GetAccountRelationships(ctx context.Context, ids []int64) ([]*Relationship, error) {
+func (c *Client) GetAccountRelationships(ctx context.Context, ids []string) ([]*Relationship, error) {
 	params := url.Values{}
 	for _, id := range ids {
-		params.Add("id[]", fmt.Sprint(id))
+		params.Add("id[]", id)
 	}
 
 	var relationships []*Relationship
@@ -246,13 +246,13 @@ func (c *Client) GetFollowRequests(ctx context.Context, pg *Pagination) ([]*Acco
 }
 
 // FollowRequestAuthorize is authorize the follow request of user with id.
-func (c *Client) FollowRequestAuthorize(ctx context.Context, id int64) error {
-	return c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/follow_requests/%d/authorize", id), nil, nil, nil)
+func (c *Client) FollowRequestAuthorize(ctx context.Context, id ID) error {
+	return c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/follow_requests/%s/authorize", url.PathEscape(string(id))), nil, nil, nil)
 }
 
 // FollowRequestReject is rejects the follow request of user with id.
-func (c *Client) FollowRequestReject(ctx context.Context, id int64) error {
-	return c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/follow_requests/%d/reject", id), nil, nil, nil)
+func (c *Client) FollowRequestReject(ctx context.Context, id ID) error {
+	return c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/follow_requests/%s/reject", url.PathEscape(string(id))), nil, nil, nil)
 }
 
 // GetMutes returns the list of users muted by the current user.

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -25,11 +25,11 @@ func TestGetAccount(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	_, err := client.GetAccount(context.Background(), 1)
+	_, err := client.GetAccount(context.Background(), "1")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	a, err := client.GetAccount(context.Background(), 1234567)
+	a, err := client.GetAccount(context.Background(), "1234567")
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
@@ -124,11 +124,11 @@ func TestGetAccountStatuses(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	_, err := client.GetAccountStatuses(context.Background(), 123, nil)
+	_, err := client.GetAccountStatuses(context.Background(), "123", nil)
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	ss, err := client.GetAccountStatuses(context.Background(), 1234567, nil)
+	ss, err := client.GetAccountStatuses(context.Background(), "1234567", nil)
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
@@ -157,11 +157,11 @@ func TestGetAccountFollowers(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	_, err := client.GetAccountFollowers(context.Background(), 123, nil)
+	_, err := client.GetAccountFollowers(context.Background(), "123", nil)
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	fl, err := client.GetAccountFollowers(context.Background(), 1234567, nil)
+	fl, err := client.GetAccountFollowers(context.Background(), "1234567", nil)
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
@@ -193,11 +193,11 @@ func TestGetAccountFollowing(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	_, err := client.GetAccountFollowing(context.Background(), 123, nil)
+	_, err := client.GetAccountFollowing(context.Background(), "123", nil)
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	fl, err := client.GetAccountFollowing(context.Background(), 1234567, nil)
+	fl, err := client.GetAccountFollowing(context.Background(), "1234567", nil)
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
@@ -267,16 +267,16 @@ func TestAccountFollow(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	rel, err := client.AccountFollow(context.Background(), 123)
+	rel, err := client.AccountFollow(context.Background(), "123")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	rel, err = client.AccountFollow(context.Background(), 1234567)
+	rel, err = client.AccountFollow(context.Background(), "1234567")
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
-	if rel.ID != 1234567 {
-		t.Fatalf("want %d but %d", 1234567, rel.ID)
+	if rel.ID != "1234567" {
+		t.Fatalf("want %q but %q", "1234567", rel.ID)
 	}
 	if !rel.Following {
 		t.Fatalf("want %t but %t", true, rel.Following)
@@ -300,16 +300,16 @@ func TestAccountUnfollow(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	rel, err := client.AccountUnfollow(context.Background(), 123)
+	rel, err := client.AccountUnfollow(context.Background(), "123")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	rel, err = client.AccountUnfollow(context.Background(), 1234567)
+	rel, err = client.AccountUnfollow(context.Background(), "1234567")
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
-	if rel.ID != 1234567 {
-		t.Fatalf("want %d but %d", 1234567, rel.ID)
+	if rel.ID != "1234567" {
+		t.Fatalf("want %q but %q", "1234567", rel.ID)
 	}
 	if rel.Following {
 		t.Fatalf("want %t but %t", false, rel.Following)
@@ -333,16 +333,16 @@ func TestAccountBlock(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	_, err := client.AccountBlock(context.Background(), 123)
+	_, err := client.AccountBlock(context.Background(), "123")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	rel, err := client.AccountBlock(context.Background(), 1234567)
+	rel, err := client.AccountBlock(context.Background(), "1234567")
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
-	if rel.ID != 1234567 {
-		t.Fatalf("want %d but %d", 1234567, rel.ID)
+	if rel.ID != "1234567" {
+		t.Fatalf("want %q but %q", "1234567", rel.ID)
 	}
 	if !rel.Blocking {
 		t.Fatalf("want %t but %t", true, rel.Blocking)
@@ -366,16 +366,16 @@ func TestAccountUnblock(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	_, err := client.AccountUnblock(context.Background(), 123)
+	_, err := client.AccountUnblock(context.Background(), "123")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	rel, err := client.AccountUnblock(context.Background(), 1234567)
+	rel, err := client.AccountUnblock(context.Background(), "1234567")
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
-	if rel.ID != 1234567 {
-		t.Fatalf("want %d but %d", 1234567, rel.ID)
+	if rel.ID != "1234567" {
+		t.Fatalf("want %q but %q", "1234567", rel.ID)
 	}
 	if rel.Blocking {
 		t.Fatalf("want %t but %t", false, rel.Blocking)
@@ -399,16 +399,16 @@ func TestAccountMute(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	_, err := client.AccountMute(context.Background(), 123)
+	_, err := client.AccountMute(context.Background(), "123")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	rel, err := client.AccountMute(context.Background(), 1234567)
+	rel, err := client.AccountMute(context.Background(), "1234567")
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
-	if rel.ID != 1234567 {
-		t.Fatalf("want %d but %d", 1234567, rel.ID)
+	if rel.ID != "1234567" {
+		t.Fatalf("want %q but %q", "1234567", rel.ID)
 	}
 	if !rel.Muting {
 		t.Fatalf("want %t but %t", true, rel.Muting)
@@ -432,16 +432,16 @@ func TestAccountUnmute(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	_, err := client.AccountUnmute(context.Background(), 123)
+	_, err := client.AccountUnmute(context.Background(), "123")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	rel, err := client.AccountUnmute(context.Background(), 1234567)
+	rel, err := client.AccountUnmute(context.Background(), "1234567")
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
-	if rel.ID != 1234567 {
-		t.Fatalf("want %d but %d", 1234567, rel.ID)
+	if rel.ID != "1234567" {
+		t.Fatalf("want %q but %q", "1234567", rel.ID)
 	}
 	if rel.Muting {
 		t.Fatalf("want %t but %t", false, rel.Muting)
@@ -465,19 +465,19 @@ func TestGetAccountRelationship(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	_, err := client.GetAccountRelationships(context.Background(), []int64{123, 456})
+	_, err := client.GetAccountRelationships(context.Background(), []string{"123", "456"})
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	rels, err := client.GetAccountRelationships(context.Background(), []int64{1234567, 8901234})
+	rels, err := client.GetAccountRelationships(context.Background(), []string{"1234567", "8901234"})
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
-	if rels[0].ID != 1234567 {
-		t.Fatalf("want %d but %d", 1234567, rels[0].ID)
+	if rels[0].ID != "1234567" {
+		t.Fatalf("want %q but %q", "1234567", rels[0].ID)
 	}
-	if rels[1].ID != 8901234 {
-		t.Fatalf("want %d but %d", 8901234, rels[1].ID)
+	if rels[1].ID != "8901234" {
+		t.Fatalf("want %q but %q", "8901234", rels[1].ID)
 	}
 }
 
@@ -599,11 +599,11 @@ func TestFollowRequestAuthorize(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	err := client.FollowRequestAuthorize(context.Background(), 123)
+	err := client.FollowRequestAuthorize(context.Background(), "123")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	err = client.FollowRequestAuthorize(context.Background(), 1234567)
+	err = client.FollowRequestAuthorize(context.Background(), "1234567")
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
@@ -623,11 +623,11 @@ func TestFollowRequestReject(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	err := client.FollowRequestReject(context.Background(), 123)
+	err := client.FollowRequestReject(context.Background(), "123")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	err = client.FollowRequestReject(context.Background(), 1234567)
+	err = client.FollowRequestReject(context.Background(), "1234567")
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}

--- a/cmd/mstdn/cmd_stream.go
+++ b/cmd/mstdn/cmd_stream.go
@@ -15,11 +15,11 @@ import (
 
 // SimpleJSON is a struct for output JSON for data to be simple used
 type SimpleJSON struct {
-	ID       int64  `json:"id"`
-	Username string `json:"username"`
-	Acct     string `json:"acct"`
-	Avatar   string `json:"avatar"`
-	Content  string `json:"content"`
+	ID       mastodon.ID `json:"id"`
+	Username string      `json:"username"`
+	Acct     string      `json:"acct"`
+	Avatar   string      `json:"avatar"`
+	Content  string      `json:"content"`
 }
 
 func checkFlag(f ...bool) bool {

--- a/compat.go
+++ b/compat.go
@@ -1,0 +1,25 @@
+package mastodon
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type ID string
+
+func (id *ID) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' && data[len(data)-1] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		*id = ID(s)
+		return nil
+	}
+	var n int64
+	if err := json.Unmarshal(data, &n); err != nil {
+		return err
+	}
+	*id = ID(fmt.Sprint(n))
+	return nil
+}

--- a/example_test.go
+++ b/example_test.go
@@ -51,7 +51,7 @@ func ExamplePagination() {
 	var followers []*mastodon.Account
 	var pg mastodon.Pagination
 	for {
-		fs, err := c.GetAccountFollowers(context.Background(), 1, &pg)
+		fs, err := c.GetAccountFollowers(context.Background(), "1", &pg)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/status.go
+++ b/status.go
@@ -11,7 +11,7 @@ import (
 
 // Status is struct to hold status.
 type Status struct {
-	ID                 int64        `json:"id"`
+	ID                 ID           `json:"id"`
 	CreatedAt          time.Time    `json:"created_at"`
 	InReplyToID        interface{}  `json:"in_reply_to_id"`
 	InReplyToAccountID interface{}  `json:"in_reply_to_account_id"`


### PR DESCRIPTION
In Mastodon 2.0 API specification, IDs are typed as string.