### PR TITLE
Fix: Type of Notification.ID was int64. Change to ID

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -9,7 +9,7 @@ import (
 
 // Notification hold information for mastodon notification.
 type Notification struct {
-	ID        int64     `json:"id"`
+	ID        ID        `json:"id"`
 	Type      string    `json:"type"`
 	CreatedAt time.Time `json:"created_at"`
 	Account   Account   `json:"account"`

--- a/notification.go
+++ b/notification.go
@@ -27,9 +27,9 @@ func (c *Client) GetNotifications(ctx context.Context, pg *Pagination) ([]*Notif
 }
 
 // GetNotification return notification.
-func (c *Client) GetNotification(ctx context.Context, id int64) (*Notification, error) {
+func (c *Client) GetNotification(ctx context.Context, id ID) (*Notification, error) {
 	var notification Notification
-	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/notifications/%d", id), nil, &notification, nil)
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/notifications/%v", id), nil, &notification, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/notification_test.go
+++ b/notification_test.go
@@ -40,17 +40,17 @@ func TestGetNotifications(t *testing.T) {
 		t.Fatalf("result should be two: %d", len(ns))
 	}
 	if ns[0].ID != "122" {
-		t.Fatalf("want %v but %v", 122, ns[0].ID)
+		t.Fatalf("want %v but %v", "122", ns[0].ID)
 	}
 	if ns[1].ID != "123" {
-		t.Fatalf("want %v but %v", 123, ns[1].ID)
+		t.Fatalf("want %v but %v", "123", ns[1].ID)
 	}
-	n, err := client.GetNotification(context.Background(), 123)
+	n, err := client.GetNotification(context.Background(), "123")
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
 	if n.ID != "123" {
-		t.Fatalf("want %v but %v", 123, n.ID)
+		t.Fatalf("want %v but %v", "123", n.ID)
 	}
 	err = client.ClearNotifications(context.Background())
 	if err != nil {

--- a/notification_test.go
+++ b/notification_test.go
@@ -39,17 +39,17 @@ func TestGetNotifications(t *testing.T) {
 	if len(ns) != 2 {
 		t.Fatalf("result should be two: %d", len(ns))
 	}
-	if ns[0].ID != 122 {
+	if ns[0].ID != "122" {
 		t.Fatalf("want %v but %v", 122, ns[0].ID)
 	}
-	if ns[1].ID != 123 {
+	if ns[1].ID != "123" {
 		t.Fatalf("want %v but %v", 123, ns[1].ID)
 	}
 	n, err := client.GetNotification(context.Background(), 123)
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
-	if n.ID != 123 {
+	if n.ID != "123" {
 		t.Fatalf("want %v but %v", 123, n.ID)
 	}
 	err = client.ClearNotifications(context.Background())

--- a/streaming_ws_test.go
+++ b/streaming_ws_test.go
@@ -117,7 +117,7 @@ func wsTest(t *testing.T, q chan Event, cancel func()) {
 	if events[0].(*UpdateEvent).Status.Content != "foo" {
 		t.Fatalf("want %q but %q", "foo", events[0].(*UpdateEvent).Status.Content)
 	}
-	if events[1].(*NotificationEvent).Notification.ID != 123 {
+	if events[1].(*NotificationEvent).Notification.ID != "123" {
 		t.Fatalf("want %d but %d", 123, events[1].(*NotificationEvent).Notification.ID)
 	}
 	if events[2].(*DeleteEvent).ID != 1234567 {


### PR DESCRIPTION
Now `mstdn.exe timeline` works fine, but

```
$ mstdn notification
json: cannot unmarshal string into Go struct field Notification.id of type int64
exit status 1
```

`Notification.ID` remains `int64`. Replacing `int64` to `ID`, `mstdn notification` works fine.
If there are no problems, would you merge ?