### PR TITLE
`mstdn.exe toot` failed because -i option's value type remained int64 yet.

### DIFF
--- a/cmd/mstdn/cmd_toot.go
+++ b/cmd/mstdn/cmd_toot.go
@@ -27,7 +27,7 @@ func cmdToot(c *cli.Context) error {
 	client := c.App.Metadata["client"].(*mastodon.Client)
 	_, err := client.PostStatus(context.Background(), &mastodon.Toot{
 		Status:      toot,
-		InReplyToID: mastodon.ID(fmt.Sprint(c.Int64("i"))),
+		InReplyToID: mastodon.ID(fmt.Sprint(c.String("i"))),
 	})
 	return err
 }

--- a/cmd/mstdn/main.go
+++ b/cmd/mstdn/main.go
@@ -199,10 +199,10 @@ func makeApp() *cli.App {
 					Usage: "post utf-8 string from a file(\"-\" means STDIN)",
 					Value: "",
 				},
-				cli.IntFlag{
+				cli.StringFlag{
 					Name:  "i",
 					Usage: "in-reply-to",
-					Value: 0,
+					Value: "",
 				},
 			},
 			Action: cmdToot,


### PR DESCRIPTION
```
$ mstdn toot hogehoge
bad request: 404 Not Found: Record not found
exit status 1
```

`-i` option's default should be empty-string, but it was 0 as int64.
I tried to fix it. Would you merge if there are no problems ?