### PR TITLE
Fixed tests for Go 1.11

### DIFF
--- a/status_test.go
+++ b/status_test.go
@@ -68,7 +68,7 @@ func TestGetStatus(t *testing.T) {
 		t.Fatal("should have emojis")
 	}
 	if status.Emojis[0].ShortCode != "💩" {
-		t.Fatalf("want %q but %q", "💩", status.Emojis[0])
+		t.Fatalf("want %q but %q", "💩", status.Emojis[0].ShortCode)
 	}
 	if status.Emojis[0].URL != "http://example.com" {
 		t.Fatalf("want %q but %q", "https://example.com", status.Emojis[0].URL)


### PR DESCRIPTION
This apparently fails with Go 1.11, as the formatting instruction `%q` doesn't match the type `status.Emojis[0]`. Looks like we always wanted to print out the short-code instead, either way.