### PR TITLE
Updated entities and json structs for API v2.6.0

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -136,12 +136,16 @@ func (c *Client) GetBlocks(ctx context.Context, pg *Pagination) ([]*Account, err
 
 // Relationship hold information for relation-ship to the account.
 type Relationship struct {
-	ID         ID   `json:"id"`
-	Following  bool `json:"following"`
-	FollowedBy bool `json:"followed_by"`
-	Blocking   bool `json:"blocking"`
-	Muting     bool `json:"muting"`
-	Requested  bool `json:"requested"`
+	ID                  ID   `json:"id"`
+	Following           bool `json:"following"`
+	FollowedBy          bool `json:"followed_by"`
+	Blocking            bool `json:"blocking"`
+	Muting              bool `json:"muting"`
+	MutingNotifications bool `json:"muting_notifications"`
+	Requested           bool `json:"requested"`
+	DomainBlocking      bool `json:"domain_blocking"`
+	ShowingReblogs      bool `json:"showing_reblogs"`
+	Endorsed            bool `json:"endorsed"`
 }
 
 // AccountFollow follow the account.

--- a/instance.go
+++ b/instance.go
@@ -7,14 +7,16 @@ import (
 
 // Instance hold information for mastodon instance.
 type Instance struct {
-	URI         string            `json:"uri"`
-	Title       string            `json:"title"`
-	Description string            `json:"description"`
-	EMail       string            `json:"email"`
-	Version     string            `json:"version,omitempty"`
-	URLs        map[string]string `json:"urls,omitempty"`
-	Stats       *InstanceStats    `json:"stats,omitempty"`
-	Thumbnail   string            `json:"thumbnail,omitempty"`
+	URI            string            `json:"uri"`
+	Title          string            `json:"title"`
+	Description    string            `json:"description"`
+	EMail          string            `json:"email"`
+	Version        string            `json:"version,omitempty"`
+	Thumbnail      string            `json:"thumbnail,omitempty"`
+	URLs           map[string]string `json:"urls,omitempty"`
+	Stats          *InstanceStats    `json:"stats,omitempty"`
+	Languages      []string          `json:"languages"`
+	ContactAccount *Account          `json:"account"`
 }
 
 // InstanceStats hold information for mastodon instance stats.

--- a/mastodon.go
+++ b/mastodon.go
@@ -211,25 +211,35 @@ type Mention struct {
 
 // Tag hold information for tag.
 type Tag struct {
-	Name string `json:"name"`
-	URL  string `json:"url"`
+	Name    string    `json:"name"`
+	URL     string    `json:"url"`
+	History []History `json:"history"`
+}
+
+// History hold information for history.
+type History struct {
+	Day      string `json:"day"`
+	Uses     int64  `json:"uses"`
+	Accounts int64  `json:"accounts"`
 }
 
 // Attachment hold information for attachment.
 type Attachment struct {
-	ID         ID     `json:"id"`
-	Type       string `json:"type"`
-	URL        string `json:"url"`
-	RemoteURL  string `json:"remote_url"`
-	PreviewURL string `json:"preview_url"`
-	TextURL    string `json:"text_url"`
+	ID          ID     `json:"id"`
+	Type        string `json:"type"`
+	URL         string `json:"url"`
+	RemoteURL   string `json:"remote_url"`
+	PreviewURL  string `json:"preview_url"`
+	TextURL     string `json:"text_url"`
+	Description string `json:"description"`
 }
 
 // Emoji hold information for CustomEmoji.
 type Emoji struct {
-	ShortCode string `json:"shortcode"`
-	URL       string `json:"url"`
-	StaticURL string `json:"static_url"`
+	ShortCode       string `json:"shortcode"`
+	StaticURL       string `json:"static_url"`
+	URL             string `json:"url"`
+	VisibleInPicker bool   `json:"visible_in_picker"`
 }
 
 // Results hold information for search result.

--- a/status.go
+++ b/status.go
@@ -11,26 +11,31 @@ import (
 // Status is struct to hold status.
 type Status struct {
 	ID                 ID           `json:"id"`
-	CreatedAt          time.Time    `json:"created_at"`
+	URI                string       `json:"uri"`
+	URL                string       `json:"url"`
+	Account            Account      `json:"account"`
 	InReplyToID        interface{}  `json:"in_reply_to_id"`
 	InReplyToAccountID interface{}  `json:"in_reply_to_account_id"`
+	Reblog             *Status      `json:"reblog"`
+	Content            string       `json:"content"`
+	CreatedAt          time.Time    `json:"created_at"`
+	Emojis             []Emoji      `json:"emojis"`
+	RepliesCount       int64        `json:"replies_count"`
+	ReblogsCount       int64        `json:"reblogs_count"`
+	FavouritesCount    int64        `json:"favourites_count"`
+	Reblogged          interface{}  `json:"reblogged"`
+	Favourited         interface{}  `json:"favourited"`
+	Muted              interface{}  `json:"muted"`
 	Sensitive          bool         `json:"sensitive"`
 	SpoilerText        string       `json:"spoiler_text"`
 	Visibility         string       `json:"visibility"`
-	Application        Application  `json:"application"`
-	Account            Account      `json:"account"`
 	MediaAttachments   []Attachment `json:"media_attachments"`
-	Emojis             []Emoji      `json:"emojis"`
 	Mentions           []Mention    `json:"mentions"`
 	Tags               []Tag        `json:"tags"`
-	URI                string       `json:"uri"`
-	Content            string       `json:"content"`
-	URL                string       `json:"url"`
-	ReblogsCount       int64        `json:"reblogs_count"`
-	FavouritesCount    int64        `json:"favourites_count"`
-	Reblog             *Status      `json:"reblog"`
-	Favourited         interface{}  `json:"favourited"`
-	Reblogged          interface{}  `json:"reblogged"`
+	Card               *Card        `json:"card"`
+	Application        Application  `json:"application"`
+	Language           string       `json:"language"`
+	Pinned             interface{}  `json:"pinned"`
 }
 
 // Context hold information for mastodon context.
@@ -41,10 +46,18 @@ type Context struct {
 
 // Card hold information for mastodon card.
 type Card struct {
-	URL         string `json:"url"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Image       string `json:"image"`
+	URL          string `json:"url"`
+	Title        string `json:"title"`
+	Description  string `json:"description"`
+	Image        string `json:"image"`
+	Type         string `json:"type"`
+	AuthorName   string `json:"author_name"`
+	AuthorURL    string `json:"author_url"`
+	ProviderName string `json:"provider_name"`
+	ProviderURL  string `json:"provider_url"`
+	HTML         string `json:"html"`
+	Width        int64  `json:"width"`
+	Height       int64  `json:"height"`
 }
 
 // GetFavourites return the favorite list of the current user.


### PR DESCRIPTION
Added missing fields to various structs and sorted them in the same order as
the original mastodon API documentation does. This should make it easier to
compare go-mastodon's structs with the original documentation.