### PR TITLE
 Add MinID to Pagination

### DIFF
--- a/cmd/mstdn/cmd_followers.go
+++ b/cmd/mstdn/cmd_followers.go
@@ -28,6 +28,7 @@ func cmdFollowers(c *cli.Context) error {
 		if pg.MaxID == "" {
 			break
 		}
+		pg.SinceID = ""
 		time.Sleep(10 * time.Second)
 	}
 	s := newScreen(config)

--- a/mastodon.go
+++ b/mastodon.go
@@ -268,6 +268,7 @@ type Results struct {
 type Pagination struct {
 	MaxID   ID
 	SinceID ID
+	MinID   ID
 	Limit   int64
 }
 
@@ -291,6 +292,12 @@ func newPagination(rawlink string) (*Pagination, error) {
 				return nil, err
 			}
 			p.SinceID = sinceID
+
+			minID, err := getPaginationID(link.URL, "min_id")
+			if err != nil {
+				return nil, err
+			}
+			p.MinID = minID
 		}
 	}
 
@@ -323,8 +330,12 @@ func (p *Pagination) toValues() url.Values {
 func (p *Pagination) setValues(params url.Values) url.Values {
 	if p.MaxID != "" {
 		params.Set("max_id", string(p.MaxID))
-	} else if p.SinceID != "" {
+	}
+	if p.SinceID != "" {
 		params.Set("since_id", string(p.SinceID))
+	}
+	if p.MinID != "" {
+		params.Set("min_id", string(p.MinID))
 	}
 	if p.Limit > 0 {
 		params.Set("limit", fmt.Sprint(p.Limit))

--- a/mastodon_test.go
+++ b/mastodon_test.go
@@ -293,6 +293,11 @@ func TestNewPagination(t *testing.T) {
 		t.Fatalf("should be fail: %v", err)
 	}
 
+	_, err = newPagination(`<http://example.com?min_id=abc>; rel="prev"`)
+	if err == nil {
+		t.Fatalf("should be fail: %v", err)
+	}
+
 	pg, err := newPagination(`<http://example.com?max_id=123>; rel="next", <http://example.com?since_id=789>; rel="prev"`)
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)

--- a/mastodon_test.go
+++ b/mastodon_test.go
@@ -328,7 +328,8 @@ func TestGetPaginationID(t *testing.T) {
 func TestPaginationSetValues(t *testing.T) {
 	p := &Pagination{
 		MaxID:   "123",
-		SinceID: "789",
+		SinceID: "456",
+		MinID:   "789",
 		Limit:   10,
 	}
 	before := url.Values{"key": {"value"}}
@@ -339,7 +340,10 @@ func TestPaginationSetValues(t *testing.T) {
 	if after.Get("max_id") != "123" {
 		t.Fatalf("want %q but %q", "123", after.Get("max_id"))
 	}
-	if after.Get("since_id") != "789" {
+	if after.Get("since_id") != "456" {
+		t.Fatalf("result should be empty string: %q", after.Get("since_id"))
+	}
+	if after.Get("min_id") != "789" {
 		t.Fatalf("result should be empty string: %q", after.Get("since_id"))
 	}
 	if after.Get("limit") != "10" {

--- a/mastodon_test.go
+++ b/mastodon_test.go
@@ -339,7 +339,7 @@ func TestPaginationSetValues(t *testing.T) {
 	if after.Get("max_id") != "123" {
 		t.Fatalf("want %q but %q", "123", after.Get("max_id"))
 	}
-	if after.Get("since_id") != "" {
+	if after.Get("since_id") != "789" {
 		t.Fatalf("result should be empty string: %q", after.Get("since_id"))
 	}
 	if after.Get("limit") != "10" {

--- a/mastodon_test.go
+++ b/mastodon_test.go
@@ -341,10 +341,10 @@ func TestPaginationSetValues(t *testing.T) {
 		t.Fatalf("want %q but %q", "123", after.Get("max_id"))
 	}
 	if after.Get("since_id") != "456" {
-		t.Fatalf("result should be empty string: %q", after.Get("since_id"))
+		t.Fatalf("want %q but %q", "456", after.Get("since_id"))
 	}
 	if after.Get("min_id") != "789" {
-		t.Fatalf("result should be empty string: %q", after.Get("since_id"))
+		t.Fatalf("want %q but %q", "789", after.Get("min_id"))
 	}
 	if after.Get("limit") != "10" {
 		t.Fatalf("want %q but %q", "10", after.Get("limit"))
@@ -361,5 +361,8 @@ func TestPaginationSetValues(t *testing.T) {
 	}
 	if after.Get("since_id") != "789" {
 		t.Fatalf("want %q but %q", "789", after.Get("since_id"))
+	}
+	if after.Get("min_id") != "" {
+		t.Fatalf("result should be empty string: %q", after.Get("min_id"))
 	}
 }


### PR DESCRIPTION
Related issue: #86 and #89

This PR adds MinID to pagination.

Also, because there is a use case that uses SinceID and MaxID simultaneously, exclusive control of SinceID and MaxID has been deleted.