### PR TITLE
Feature: UploadMediaFromReader (using io.Reader to upload procedurally-generated/ephemeral files directly)

### DIFF
--- a/mastodon.go
+++ b/mastodon.go
@@ -83,6 +83,26 @@ func (c *Client) doAPI(ctx context.Context, method string, uri string, params in
 			return err
 		}
 		ct = mw.FormDataContentType()
+	} else if reader, ok := params.(io.Reader); ok {
+		var buf bytes.Buffer
+		mw := multipart.NewWriter(&buf)
+		part, err := mw.CreateFormFile("file", "upload")
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(part, reader)
+		if err != nil {
+			return err
+		}
+		err = mw.Close()
+		if err != nil {
+			return err
+		}
+		req, err = http.NewRequest(method, u.String(), &buf)
+		if err != nil {
+			return err
+		}
+		ct = mw.FormDataContentType()
 	} else {
 		if method == http.MethodGet && pg != nil {
 			u.RawQuery = pg.toValues().Encode()

--- a/status.go
+++ b/status.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+	"io"
 )
 
 // Status is struct to hold status.
@@ -265,10 +266,20 @@ func (c *Client) Search(ctx context.Context, q string, resolve bool) (*Results, 
 	return &results, nil
 }
 
-// UploadMedia upload a media attachment.
+// UploadMedia upload a media attachment from a file.
 func (c *Client) UploadMedia(ctx context.Context, file string) (*Attachment, error) {
 	var attachment Attachment
 	err := c.doAPI(ctx, http.MethodPost, "/api/v1/media", file, &attachment, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &attachment, nil
+}
+
+// UploadMediaFromReader uploads a media attachment from a io.Reader.
+func (c *Client) UploadMediaFromReader(ctx context.Context, reader io.Reader) (*Attachment, error) {
+	var attachment Attachment
+	err := c.doAPI(ctx, http.MethodPost, "/api/v1/media", reader, &attachment, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/status_test.go
+++ b/status_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"os"
 )
 
 func TestGetFavourites(t *testing.T) {
@@ -547,6 +548,15 @@ func TestUploadMedia(t *testing.T) {
 		t.Fatalf("should not be fail: %v", err)
 	}
 	if attachment.ID != "123" {
+		t.Fatalf("want %q but %q", "123", attachment.ID)
+	}
+	file, err := os.Open("testdata/logo.png")
+	defer file.Close()
+	writerAttachment, err := client.UploadMediaFromReader(context.Background(), file)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if writerAttachment.ID != "123" {
 		t.Fatalf("want %q but %q", "123", attachment.ID)
 	}
 }


### PR DESCRIPTION
A rough implementation of a `client.UploadMedia` derivative which takes an `io.Reader` instead of a filepath string. I make a lot of bots and programs that generate content procedurally and having to use and manage `ioutil.TempFile` stuff can be a pain.

Implementation is simple as it comes - mostly adapting the already existing code for dealing with filepaths in `doAPI` to handle taking a reader directly.

This could be packed into the UploadMedia function pretty cleanly as well (using interface{} and a type switch) but that change could be breaking and would probably need more documentation to avoid confusion.

Let me know how I can improve this. First time contributing code to a public repo.