### PR TITLE
WIP: Added polls entity, available since API 2.8.0

### DIFF
--- a/polls.go
+++ b/polls.go
@@ -1,0 +1,20 @@
+package mastodon
+
+import "time"
+
+// Poll hold information for mastodon polls.
+type Poll struct {
+	ID         ID           `json:"id"`
+	ExpiresAt  time.Time    `json:"expires_at"`
+	Expired    bool         `json:"expired"`
+	Multiple   bool         `json:"multiple"`
+	VotesCount int64        `json:"votes_count"`
+	Options    []PollOption `json:"options"`
+	Voted      bool         `json:"voted"`
+}
+
+// Poll hold information for a mastodon poll option.
+type PollOption struct {
+	Title      string `json:"title"`
+	VotesCount int64  `json:"votes_count"`
+}

--- a/status.go
+++ b/status.go
@@ -34,6 +34,7 @@ type Status struct {
 	Mentions           []Mention    `json:"mentions"`
 	Tags               []Tag        `json:"tags"`
 	Card               *Card        `json:"card"`
+	Poll               *Poll        `json:"poll"`
 	Application        Application  `json:"application"`
 	Language           string       `json:"language"`
 	Pinned             interface{}  `json:"pinned"`


### PR DESCRIPTION
So far this is a self-contained pull request for (read-only) accessing polls, available since the 2.8.0 release of Mastodon.

API calls for voting and retrieving votes will be added, either here or in a separate pull request.