### PR TITLE
Add support for Field, Source and Locked parameters to AccountUpdate()

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -41,10 +41,10 @@ type Field struct {
 
 // AccountSource is a Mastodon account profile field.
 type AccountSource struct {
-	Privacy   string   `json:"privacy"`
+	Privacy   *string   `json:"privacy"`
 	Sensitive *bool    `json:"sensitive"`
-	Language  string   `json:"language"`
-	Note      string   `json:"note"`
+	Language  *string   `json:"language"`
+	Note      *string   `json:"note"`
 	Fields    *[]Field `json:"fields"`
 }
 
@@ -102,14 +102,14 @@ func (c *Client) AccountUpdate(ctx context.Context, profile *Profile) (*Account,
 		}
 	}
 	if profile.Source != nil {
-		if len(profile.Source.Privacy) > 0 {
-			params.Set("source[privacy]", profile.Source.Privacy)
+		if profile.Source.Privacy != nil {
+			params.Set("source[privacy]", *profile.Source.Privacy)
 		}
 		if profile.Source.Sensitive != nil {
 			params.Set("source[sensitive]", strconv.FormatBool(*profile.Source.Sensitive))
 		}
-		if len(profile.Source.Language) > 0 {
-			params.Set("source[language]", profile.Source.Language)
+		if profile.Source.Language != nil {
+			params.Set("source[language]", *profile.Source.Language)
 		}
 	}
 	if profile.Avatar != "" {

--- a/accounts.go
+++ b/accounts.go
@@ -39,8 +39,8 @@ type Field struct {
 	VerifiedAt time.Time `json:"verified_at"`
 }
 
-// Source is a Mastodon account profile field
-type Source struct {
+// AccountSource is a Mastodon account profile field.
+type AccountSource struct {
 	Privacy   string   `json:"privacy"`
 	Sensitive *bool    `json:"sensitive"`
 	Language  string   `json:"language"`
@@ -76,7 +76,7 @@ type Profile struct {
 	Note        *string
 	Locked      *bool
 	Fields      *[]Field
-	Source      *Source
+	Source      *AccountSource
 
 	// Set the base64 encoded character string of the image.
 	Avatar string

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -96,7 +96,7 @@ func TestAccountUpdate(t *testing.T) {
 	}
 	tbool := true
 	fields := []Field{{"foo", "bar", time.Time{}}, {"dum", "baz", time.Time{}}}
-	source := AccountSource{Language: "de", Privacy: "public", Sensitive: &tbool}
+	source := AccountSource{Language: String("de"), Privacy: String("public"), Sensitive: &tbool}
 	a, err := client.AccountUpdate(context.Background(), &Profile{
 		DisplayName: String("display_name"),
 		Note:        String("note"),

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestGetAccount(t *testing.T) {
@@ -93,9 +94,15 @@ func TestAccountUpdate(t *testing.T) {
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
+	tbool := true
+	fields := []Field{{"foo", "bar", time.Time{}}, {"dum", "baz", time.Time{}}}
+	source := Source{Language: "de", Privacy: "public", Sensitive: &tbool}
 	a, err := client.AccountUpdate(context.Background(), &Profile{
 		DisplayName: String("display_name"),
 		Note:        String("note"),
+		Locked:      &tbool,
+		Fields:      &fields,
+		Source:      &source,
 		Avatar:      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUoAAADrCAYAAAA...",
 		Header:      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAUoAAADrCAYAAAA...",
 	})

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -96,7 +96,7 @@ func TestAccountUpdate(t *testing.T) {
 	}
 	tbool := true
 	fields := []Field{{"foo", "bar", time.Time{}}, {"dum", "baz", time.Time{}}}
-	source := Source{Language: "de", Privacy: "public", Sensitive: &tbool}
+	source := AccountSource{Language: "de", Privacy: "public", Sensitive: &tbool}
 	a, err := client.AccountUpdate(context.Background(), &Profile{
 		DisplayName: String("display_name"),
 		Note:        String("note"),


### PR DESCRIPTION
A few parameters were missing for the `update_credentials` endpoint.

Reference: https://docs.joinmastodon.org/api/rest/accounts/#patch-api-v1-accounts-update-credentials