### PR TITLE
Fixed pagination parsing for non-numeric IDs

### DIFF
--- a/mastodon.go
+++ b/mastodon.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -352,17 +351,7 @@ func getPaginationID(rawurl, key string) (ID, error) {
 		return "", err
 	}
 
-	val := u.Query().Get(key)
-	if val == "" {
-		return "", nil
-	}
-
-	id, err := strconv.ParseInt(val, 10, 64)
-	if err != nil {
-		return "", err
-	}
-
-	return ID(fmt.Sprint(id)), nil
+	return ID(u.Query().Get(key)), nil
 }
 
 func (p *Pagination) toValues() url.Values {

--- a/mastodon_test.go
+++ b/mastodon_test.go
@@ -294,8 +294,8 @@ func TestNewPagination(t *testing.T) {
 	}
 
 	_, err = newPagination(`<http://example.com?min_id=abc>; rel="prev"`)
-	if err == nil {
-		t.Fatalf("should be fail: %v", err)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
 	}
 
 	pg, err := newPagination(`<http://example.com?max_id=123>; rel="next", <http://example.com?since_id=789>; rel="prev"`)
@@ -317,8 +317,8 @@ func TestGetPaginationID(t *testing.T) {
 	}
 
 	_, err = getPaginationID("http://example.com?max_id=abc", "max_id")
-	if err == nil {
-		t.Fatalf("should be fail: %v", err)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
 	}
 
 	id, err := getPaginationID("http://example.com?max_id=123", "max_id")


### PR DESCRIPTION
Mastodon API's pagination IDs are not guaranteed to be in a numeric format.
This happens to be the case for the tootsuite implementation, but others
use UUIDs or flake IDs for pagination.

This also simplifies the code a bit and luckily shouldn't break backwards
compatibility since they're already of type ID in the Pagination struct.