### PR TITLE
Add support for /api/v1/push/subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ func main() {
 * [x] GET /api/v1/notifications/:id
 * [x] POST /api/v1/notifications/dismiss
 * [x] POST /api/v1/notifications/clear
+* [x] POST /api/v1/push/subscription
+* [x] GET /api/v1/push/subscription
+* [x] PUT /api/v1/push/subscription
+* [x] DELETE /api/v1/push/subscription
 * [x] GET /api/v1/reports
 * [x] POST /api/v1/reports
 * [x] GET /api/v1/search

--- a/accounts.go
+++ b/accounts.go
@@ -41,10 +41,10 @@ type Field struct {
 
 // AccountSource is a Mastodon account profile field.
 type AccountSource struct {
-	Privacy   *string   `json:"privacy"`
+	Privacy   *string  `json:"privacy"`
 	Sensitive *bool    `json:"sensitive"`
-	Language  *string   `json:"language"`
-	Note      *string   `json:"note"`
+	Language  *string  `json:"language"`
+	Note      *string  `json:"note"`
 	Fields    *[]Field `json:"fields"`
 }
 

--- a/compat.go
+++ b/compat.go
@@ -3,6 +3,7 @@ package mastodon
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 type ID string
@@ -21,5 +22,28 @@ func (id *ID) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	*id = ID(fmt.Sprint(n))
+	return nil
+}
+
+type Sbool bool
+
+func (s *Sbool) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' && data[len(data)-1] == '"' {
+		var str string
+		if err := json.Unmarshal(data, &str); err != nil {
+			return err
+		}
+		b, err := strconv.ParseBool(str)
+		if err != nil {
+			return err
+		}
+		*s = Sbool(b)
+		return nil
+	}
+	var b bool
+	if err := json.Unmarshal(data, &b); err != nil {
+		return err
+	}
+	*s = Sbool(b)
 	return nil
 }

--- a/notification.go
+++ b/notification.go
@@ -2,9 +2,13 @@ package mastodon
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -15,6 +19,20 @@ type Notification struct {
 	CreatedAt time.Time `json:"created_at"`
 	Account   Account   `json:"account"`
 	Status    *Status   `json:"status"`
+}
+
+type PushSubscription struct {
+	ID        ID          `json:"id"`
+	Endpoint  string      `json:"endpoint"`
+	ServerKey string      `json:"server_key"`
+	Alerts    *PushAlerts `json:"alerts"`
+}
+
+type PushAlerts struct {
+	Follow    *Sbool `json:"follow"`
+	Favourite *Sbool `json:"favourite"`
+	Reblog    *Sbool `json:"reblog"`
+	Mention   *Sbool `json:"mention"`
 }
 
 // GetNotifications return notifications.
@@ -51,4 +69,69 @@ func (c *Client) DismissNotification(ctx context.Context, id ID) error {
 // ClearNotifications clear notifications.
 func (c *Client) ClearNotifications(ctx context.Context) error {
 	return c.doAPI(ctx, http.MethodPost, "/api/v1/notifications/clear", nil, nil, nil)
+}
+
+// AddPushSubscription adds a new push subscription.
+func (c *Client) AddPushSubscription(ctx context.Context, endpoint string, public ecdsa.PublicKey, shared []byte, alerts PushAlerts) (*PushSubscription, error) {
+	var subscription PushSubscription
+	pk := elliptic.Marshal(public.Curve, public.X, public.Y)
+	params := url.Values{}
+	params.Add("subscription[endpoint]", endpoint)
+	params.Add("subscription[keys][p256dh]", base64.RawURLEncoding.EncodeToString(pk))
+	params.Add("subscription[keys][auth]", base64.RawURLEncoding.EncodeToString(shared))
+	if alerts.Follow != nil {
+		params.Add("data[alerts][follow]", strconv.FormatBool(bool(*alerts.Follow)))
+	}
+	if alerts.Favourite != nil {
+		params.Add("data[alerts][favourite]", strconv.FormatBool(bool(*alerts.Favourite)))
+	}
+	if alerts.Reblog != nil {
+		params.Add("data[alerts][reblog]", strconv.FormatBool(bool(*alerts.Reblog)))
+	}
+	if alerts.Mention != nil {
+		params.Add("data[alerts][mention]", strconv.FormatBool(bool(*alerts.Mention)))
+	}
+	err := c.doAPI(ctx, http.MethodPost, "/api/v1/push/subscription", params, &subscription, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &subscription, nil
+}
+
+// UpdatePushSubscription updates which type of notifications are sent for the active push subscription.
+func (c *Client) UpdatePushSubscription(ctx context.Context, alerts *PushAlerts) (*PushSubscription, error) {
+	var subscription PushSubscription
+	params := url.Values{}
+	if alerts.Follow != nil {
+		params.Add("data[alerts][follow]", strconv.FormatBool(bool(*alerts.Follow)))
+	}
+	if alerts.Mention != nil {
+		params.Add("data[alerts][favourite]", strconv.FormatBool(bool(*alerts.Favourite)))
+	}
+	if alerts.Reblog != nil {
+		params.Add("data[alerts][reblog]", strconv.FormatBool(bool(*alerts.Reblog)))
+	}
+	if alerts.Mention != nil {
+		params.Add("data[alerts][mention]", strconv.FormatBool(bool(*alerts.Mention)))
+	}
+	err := c.doAPI(ctx, http.MethodPut, "/api/v1/push/subscription", params, &subscription, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &subscription, nil
+}
+
+// RemovePushSubscription deletes the active push subscription.
+func (c *Client) RemovePushSubscription(ctx context.Context) error {
+	return c.doAPI(ctx, http.MethodDelete, "/api/v1/push/subscription", nil, nil, nil)
+}
+
+// GetPushSubscription retrieves information about the active push subscription.
+func (c *Client) GetPushSubscription(ctx context.Context) (*PushSubscription, error) {
+	var subscription PushSubscription
+	err := c.doAPI(ctx, http.MethodGet, "/api/v1/push/subscription", nil, &subscription, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &subscription, nil
 }

--- a/notification_test.go
+++ b/notification_test.go
@@ -72,7 +72,7 @@ func TestPushSubscription(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v1/push/subscription":
-			fmt.Fprintln(w, ` {"id":1,"endpoint":"https://example.org","alerts":{"follow":"true","favourite":"true","reblog":"true","mention":"true"},"server_key":"foobar"}`)
+			fmt.Fprintln(w, ` {"id":1,"endpoint":"https://example.org","alerts":{"follow":true,"favourite":"true","reblog":"true","mention":"true"},"server_key":"foobar"}`)
 			return
 		}
 		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)


### PR DESCRIPTION
As title states this adds support for all `/api/v1/push/subscription` methods.
I had to add Sbool type because of https://github.com/tootsuite/mastodon/issues/10789.