### PR TITLE
Use a slightly more aggressive backoff approach

### DIFF
--- a/mastodon.go
+++ b/mastodon.go
@@ -123,7 +123,7 @@ func (c *Client) doAPI(ctx context.Context, method string, uri string, params in
 	}
 
 	var resp *http.Response
-	backoff := 1000 * time.Millisecond
+	backoff := time.Second
 	for {
 		resp, err = c.Do(req)
 		if err != nil {
@@ -137,13 +137,14 @@ func (c *Client) doAPI(ctx context.Context, method string, uri string, params in
 			if backoff > time.Hour {
 				break
 			}
-			backoff *= 2
 
 			select {
 			case <-time.After(backoff):
 			case <-ctx.Done():
 				return ctx.Err()
 			}
+
+			backoff = time.Duration(1.5 * float64(backoff))
 			continue
 		}
 		break


### PR DESCRIPTION
Doubling the backoff every iteration turned out to be a bit
too relaxed for the common situations where you run into API
throttling. This change gives the API enough room to breathe,
but re-tries requests just a little more often.