### PR TITLE
Simplify code

### DIFF
--- a/accounts_test.go
+++ b/accounts_test.go
@@ -16,7 +16,6 @@ func TestGetAccount(t *testing.T) {
 			return
 		}
 		fmt.Fprintln(w, `{"username": "zzz"}`)
-		return
 	}))
 	defer ts.Close()
 
@@ -48,7 +47,6 @@ func TestGetAccountCurrentUser(t *testing.T) {
 			return
 		}
 		fmt.Fprintln(w, `{"username": "zzz"}`)
-		return
 	}))
 	defer ts.Close()
 
@@ -80,7 +78,6 @@ func TestAccountUpdate(t *testing.T) {
 			return
 		}
 		fmt.Fprintln(w, `{"username": "zzz"}`)
-		return
 	}))
 	defer ts.Close()
 

--- a/cmd/mstdn/cmd_stream_test.go
+++ b/cmd/mstdn/cmd_stream_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestCmdStream(t *testing.T) {
-	var ts *httptest.Server
-	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/streaming/public/local" {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return


### PR DESCRIPTION
- Removed redundant returns
- Implicitly declare httptest.Server