### PR TITLE
Make Client.Config public

### DIFF
--- a/mastodon.go
+++ b/mastodon.go
@@ -31,12 +31,12 @@ type Config struct {
 // Client is a API client for mastodon.
 type Client struct {
 	http.Client
-	config    *Config
+	Config    *Config
 	UserAgent string
 }
 
 func (c *Client) doAPI(ctx context.Context, method string, uri string, params interface{}, res interface{}, pg *Pagination) error {
-	u, err := url.Parse(c.config.Server)
+	u, err := url.Parse(c.Config.Server)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func (c *Client) doAPI(ctx context.Context, method string, uri string, params in
 		}
 	}
 	req = req.WithContext(ctx)
-	req.Header.Set("Authorization", "Bearer "+c.config.AccessToken)
+	req.Header.Set("Authorization", "Bearer "+c.Config.AccessToken)
 	if params != nil {
 		req.Header.Set("Content-Type", ct)
 	}
@@ -170,15 +170,15 @@ func (c *Client) doAPI(ctx context.Context, method string, uri string, params in
 func NewClient(config *Config) *Client {
 	return &Client{
 		Client: *http.DefaultClient,
-		config: config,
+		Config: config,
 	}
 }
 
 // Authenticate get access-token to the API.
 func (c *Client) Authenticate(ctx context.Context, username, password string) error {
 	params := url.Values{
-		"client_id":     {c.config.ClientID},
-		"client_secret": {c.config.ClientSecret},
+		"client_id":     {c.Config.ClientID},
+		"client_secret": {c.Config.ClientSecret},
 		"grant_type":    {"password"},
 		"username":      {username},
 		"password":      {password},
@@ -193,8 +193,8 @@ func (c *Client) Authenticate(ctx context.Context, username, password string) er
 // redirectURI should be the same as Application.RedirectURI.
 func (c *Client) AuthenticateToken(ctx context.Context, authCode, redirectURI string) error {
 	params := url.Values{
-		"client_id":     {c.config.ClientID},
-		"client_secret": {c.config.ClientSecret},
+		"client_id":     {c.Config.ClientID},
+		"client_secret": {c.Config.ClientSecret},
 		"grant_type":    {"authorization_code"},
 		"code":          {authCode},
 		"redirect_uri":  {redirectURI},
@@ -204,7 +204,7 @@ func (c *Client) AuthenticateToken(ctx context.Context, authCode, redirectURI st
 }
 
 func (c *Client) authenticate(ctx context.Context, params url.Values) error {
-	u, err := url.Parse(c.config.Server)
+	u, err := url.Parse(c.Config.Server)
 	if err != nil {
 		return err
 	}
@@ -236,7 +236,7 @@ func (c *Client) authenticate(ctx context.Context, params url.Values) error {
 	if err != nil {
 		return err
 	}
-	c.config.AccessToken = res.AccessToken
+	c.Config.AccessToken = res.AccessToken
 	return nil
 }
 

--- a/streaming.go
+++ b/streaming.go
@@ -80,7 +80,7 @@ func handleReader(q chan Event, r io.Reader) error {
 }
 
 func (c *Client) streaming(ctx context.Context, p string, params url.Values) (chan Event, error) {
-	u, err := url.Parse(c.config.Server)
+	u, err := url.Parse(c.Config.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (c *Client) streaming(ctx context.Context, p string, params url.Values) (ch
 		return nil, err
 	}
 	req = req.WithContext(ctx)
-	req.Header.Set("Authorization", "Bearer "+c.config.AccessToken)
+	req.Header.Set("Authorization", "Bearer "+c.Config.AccessToken)
 
 	q := make(chan Event)
 	go func() {

--- a/streaming_ws.go
+++ b/streaming_ws.go
@@ -58,13 +58,13 @@ func (c *WSClient) StreamingWSList(ctx context.Context, id ID) (chan Event, erro
 
 func (c *WSClient) streamingWS(ctx context.Context, stream, tag string) (chan Event, error) {
 	params := url.Values{}
-	params.Set("access_token", c.client.config.AccessToken)
+	params.Set("access_token", c.client.Config.AccessToken)
 	params.Set("stream", stream)
 	if tag != "" {
 		params.Set("tag", tag)
 	}
 
-	u, err := changeWebSocketScheme(c.client.config.Server)
+	u, err := changeWebSocketScheme(c.client.Config.Server)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Make `Client.Config` public to have access to `AccessToken` after authentication
Closes #114 