### PR TITLE
Fix History struct members

### DIFF
--- a/mastodon.go
+++ b/mastodon.go
@@ -277,8 +277,8 @@ type Tag struct {
 // History hold information for history.
 type History struct {
 	Day      string `json:"day"`
-	Uses     int64  `json:"uses"`
-	Accounts int64  `json:"accounts"`
+	Uses     string `json:"uses"`
+	Accounts string `json:"accounts"`
 }
 
 // Attachment hold information for attachment.


### PR DESCRIPTION
The Mastodon API actually returns these numbers as strings instead of integers (at least in the most recent version).