### PR TITLE
Update search to use v2 API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ func main() {
 * [x] DELETE /api/v1/push/subscription
 * [x] GET /api/v1/reports
 * [x] POST /api/v1/reports
-* [x] GET /api/v1/search
+* [x] GET /api/v2/search
 * [x] GET /api/v1/statuses/:id
 * [x] GET /api/v1/statuses/:id/context
 * [x] GET /api/v1/statuses/:id/card

--- a/cmd/mstdn/cmd_search_test.go
+++ b/cmd/mstdn/cmd_search_test.go
@@ -13,8 +13,8 @@ func TestCmdSearch(t *testing.T) {
 	out := testWithServer(
 		func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
-			case "/api/v1/search":
-				fmt.Fprintln(w, `{"accounts": [{"id": 234, "acct": "zzz"}], "statuses":[{"id": 345, "content": "yyy"}], "hashtags": ["www", "わろす"]}`)
+			case "/api/v2/search":
+				fmt.Fprintln(w, `{"accounts": [{"id": 234, "acct": "zzz"}], "statuses":[{"id": 345, "content": "yyy"}], "hashtags": [{"name": "www"}, {"name": "わろす"}]}`)
 				return
 			}
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)

--- a/mastodon.go
+++ b/mastodon.go
@@ -319,7 +319,7 @@ type Emoji struct {
 type Results struct {
 	Accounts []*Account `json:"accounts"`
 	Statuses []*Status  `json:"statuses"`
-	Hashtags []string   `json:"hashtags"`
+	Hashtags []*Tag     `json:"hashtags"`
 }
 
 // Pagination is a struct for specifying the get range.

--- a/status.go
+++ b/status.go
@@ -277,7 +277,7 @@ func (c *Client) Search(ctx context.Context, q string, resolve bool) (*Results, 
 	params.Set("q", q)
 	params.Set("resolve", fmt.Sprint(resolve))
 	var results Results
-	err := c.doAPI(ctx, http.MethodGet, "/api/v1/search", params, &results, nil)
+	err := c.doAPI(ctx, http.MethodGet, "/api/v2/search", params, &results, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/status_test.go
+++ b/status_test.go
@@ -532,11 +532,11 @@ func TestDeleteStatus(t *testing.T) {
 
 func TestSearch(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/search" {
+		if r.URL.Path != "/api/v2/search" {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
-		if r.RequestURI != "/api/v1/search?q=q&resolve=false" {
+		if r.RequestURI != "/api/v2/search?q=q&resolve=false" {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusBadRequest)
 			return
 		}
@@ -544,7 +544,7 @@ func TestSearch(t *testing.T) {
 		fmt.Fprintln(w, `
 			{"accounts":[{"username": "zzz"},{"username": "yyy"}],
 			"statuses":[{"content": "aaa"}],
-			"hashtags":["tag","tag2","tag3"]
+			"hashtags":[{"name": "tag"},{"name": "tag2"},{"name": "tag3"}]
 		}`)
 		return
 	}))
@@ -575,7 +575,7 @@ func TestSearch(t *testing.T) {
 	if len(ret.Hashtags) != 3 {
 		t.Fatalf("Hashtags have %q entries, but %q", "3", len(ret.Hashtags))
 	}
-	if ret.Hashtags[2] != "tag3" {
+	if ret.Hashtags[2].Name != "tag3" {
 		t.Fatalf("Hashtags[2] should %q , but %q", "tag3", ret.Hashtags[2])
 	}
 }


### PR DESCRIPTION
v1 has been disabled on most instances by now.
The change is minor: hash-tags are now reported as proper structs
instead of a simple string-array.