### PR TITLE
Add streaming direct support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ func main() {
 * [x] GET /api/v1/timelines/public
 * [x] GET /api/v1/timelines/tag/:hashtag
 * [x] GET /api/v1/timelines/list/:id
+* [x] GET /api/v1/streaming/user
+* [x] GET /api/v1/streaming/public
+* [x] GET /api/v1/streaming/hashtag?tag=:hashtag
+* [x] GET /api/v1/streaming/hashtag/local?tag=:hashtag
+* [x] GET /api/v1/streaming/list?list=:list_id
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ func main() {
 * [x] GET /api/v1/streaming/hashtag?tag=:hashtag
 * [x] GET /api/v1/streaming/hashtag/local?tag=:hashtag
 * [x] GET /api/v1/streaming/list?list=:list_id
+* [x] GET /api/v1/streaming/direct
 
 ## Installation
 

--- a/streaming.go
+++ b/streaming.go
@@ -164,3 +164,8 @@ func (c *Client) StreamingList(ctx context.Context, id ID) (chan Event, error) {
 
 	return c.streaming(ctx, "list", params)
 }
+
+// StreamingDirect return channel to read events on a direct messages.
+func (c *Client) StreamingDirect(ctx context.Context) (chan Event, error) {
+	return c.streaming(ctx, "direct", nil)
+}


### PR DESCRIPTION
The `/api/v1/streaming/direct` endpoint was missing.

streaming: https://docs.joinmastodon.org/methods/timelines/streaming/