### PR TITLE
Use Conversations.

### DIFF
--- a/cmd/mstdn/cmd_timeline_test.go
+++ b/cmd/mstdn/cmd_timeline_test.go
@@ -19,8 +19,8 @@ func TestCmdTimeline(t *testing.T) {
 			case "/api/v1/timelines/public":
 				fmt.Fprintln(w, `[{"content": "public"}]`)
 				return
-			case "/api/v1/timelines/direct":
-				fmt.Fprintln(w, `[{"content": "direct"}]`)
+			case "/api/v1/conversations":
+				fmt.Fprintln(w, `[{"id": "4", "unread":false, "last_status" : {"content": "direct"}}]`)
 				return
 			}
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)

--- a/status.go
+++ b/status.go
@@ -383,11 +383,19 @@ func (c *Client) UploadMediaFromMedia(ctx context.Context, media *Media) (*Attac
 func (c *Client) GetTimelineDirect(ctx context.Context, pg *Pagination) ([]*Status, error) {
 	params := url.Values{}
 
-	var statuses []*Status
-	err := c.doAPI(ctx, http.MethodGet, "/api/v1/timelines/direct", params, &statuses, pg)
+	var conversations []*Conversation
+	err := c.doAPI(ctx, http.MethodGet, "/api/v1/conversations", params, &conversations, pg)
 	if err != nil {
 		return nil, err
 	}
+
+	var statuses []*Status
+
+	for _, c := range conversations {
+		s := c.LastStatus
+		statuses = append(statuses, s)
+	}
+
 	return statuses, nil
 }
 

--- a/status.go
+++ b/status.go
@@ -389,7 +389,7 @@ func (c *Client) GetTimelineDirect(ctx context.Context, pg *Pagination) ([]*Stat
 		return nil, err
 	}
 
-	var statuses []*Status
+	var statuses = make([]*Status, len(conversations))
 
 	for _, c := range conversations {
 		s := c.LastStatus

--- a/status.go
+++ b/status.go
@@ -389,7 +389,7 @@ func (c *Client) GetTimelineDirect(ctx context.Context, pg *Pagination) ([]*Stat
 		return nil, err
 	}
 
-	var statuses = make([]*Status, len(conversations))
+	var statuses = []*Status{}
 
 	for _, c := range conversations {
 		s := c.LastStatus

--- a/status_test.go
+++ b/status_test.go
@@ -381,7 +381,6 @@ func TestGetTimelineDirect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
-	t.Logf("%#v", tl)
 	if len(tl) != 2 {
 		t.Fatalf("result should be two: %d", len(tl))
 	}

--- a/status_test.go
+++ b/status_test.go
@@ -372,7 +372,7 @@ func TestGetTimelinePublic(t *testing.T) {
 
 func TestGetTimelineDirect(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `[{"content": "direct"}, {"content": "status"}]`)
+		fmt.Fprintln(w, `[{"id": "4", "unread":false, "last_status" : {"content": "zzz"}}, {"id": "3", "unread":true, "last_status" : {"content": "bar"}}]`)
 	}))
 	defer ts.Close()
 
@@ -381,13 +381,14 @@ func TestGetTimelineDirect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
+	t.Logf("%#v", tl)
 	if len(tl) != 2 {
 		t.Fatalf("result should be two: %d", len(tl))
 	}
-	if tl[0].Content != "direct" {
+	if tl[0].Content != "zzz" {
 		t.Fatalf("want %q but %q", "foo", tl[0].Content)
 	}
-	if tl[1].Content != "status" {
+	if tl[1].Content != "bar" {
 		t.Fatalf("want %q but %q", "bar", tl[1].Content)
 	}
 }


### PR DESCRIPTION
I've been told using `/api/v1/timelines/direct` was deprecated so I patched it to use `/api/v1/conversations` instead.  That way, API is not modified.