### PR TITLE
Replace deprecated /api/v1/notifications/dismiss with new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ func main() {
 * [x] GET /api/v1/mutes
 * [x] GET /api/v1/notifications
 * [x] GET /api/v1/notifications/:id
-* [x] POST /api/v1/notifications/dismiss
+* [x] POST /api/v1/notifications/:id/dismiss
 * [x] POST /api/v1/notifications/clear
 * [x] POST /api/v1/push/subscription
 * [x] GET /api/v1/push/subscription

--- a/notification.go
+++ b/notification.go
@@ -57,13 +57,7 @@ func (c *Client) GetNotification(ctx context.Context, id ID) (*Notification, err
 
 // DismissNotification deletes a single notification.
 func (c *Client) DismissNotification(ctx context.Context, id ID) error {
-	params := url.Values{}
-	params.Add("id", string(id))
-	err := c.doAPI(ctx, http.MethodPost, "/api/v1/notifications/dismiss", params, nil, nil)
-	if err != nil {
-		return err
-	}
-	return nil
+	return c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/notifications/%v/dismiss", id), nil, nil, nil)
 }
 
 // ClearNotifications clear notifications.

--- a/notification_test.go
+++ b/notification_test.go
@@ -23,7 +23,7 @@ func TestGetNotifications(t *testing.T) {
 		case "/api/v1/notifications/clear":
 			fmt.Fprintln(w, `{}`)
 			return
-		case "/api/v1/notifications/dismiss":
+		case "/api/v1/notifications/123/dismiss":
 			fmt.Fprintln(w, `{}`)
 			return
 		}


### PR DESCRIPTION
Use /api/v1/notifications/:id/dismiss instead of deprecated /api/v1/notifications/dismiss.