### PR TITLE
Enable anonymous streaming

### DIFF
--- a/streaming.go
+++ b/streaming.go
@@ -92,7 +92,10 @@ func (c *Client) streaming(ctx context.Context, p string, params url.Values) (ch
 		return nil, err
 	}
 	req = req.WithContext(ctx)
-	req.Header.Set("Authorization", "Bearer "+c.Config.AccessToken)
+
+	if c.Config.AccessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Config.AccessToken)
+	}
 
 	q := make(chan Event)
 	go func() {


### PR DESCRIPTION
The purpose of this PR is to enable anonymous (unauthenticated) streaming.

This curl command demonstrates that streaming works (at least on some instances) without a need for authentication.

```nohighlight
curl https://mastodon.social/api/v1/streaming/public
```

With v0.0.4, we assume that an AccessToken is set and use it to set an `Authorization` header in the request. With an empty AccessToken, this leads to an authorization error.

Omitting the entire header in that case fixes the problem. The following programm illustrates it.

```go
package main

import (
	"context"
	"log"

	mastodon "github.com/mattn/go-mastodon"
)

const serverURL = "https://mastodon.social"

func main() {
	ctx := context.Background()

	client := mastodon.NewClient(&mastodon.Config{
		Server: serverURL,
	})

	q, err := client.StreamingPublic(ctx, false)
	if err != nil {
		log.Fatalf("StreamingPublic failed: %v", err)
	}

	for e := range q {
		switch event := e.(type) {
		case *mastodon.UpdateEvent:
			log.Printf("UpdateEvent: account %s", event.Status.Account.URL)
		case *mastodon.NotificationEvent:
			log.Printf("NotificationEvent: type %#v", event.Notification.Type)
		case *mastodon.ErrorEvent:
			log.Printf("ErrorEvent: %#v", event)
		}
	}
}

```