### PR TITLE
Remove unused variables

### DIFF
--- a/accounts_test.go
+++ b/accounts_test.go
@@ -303,11 +303,11 @@ func TestAccountFollow(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	rel, err := client.AccountFollow(context.Background(), "123")
+	_, err := client.AccountFollow(context.Background(), "123")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	rel, err = client.AccountFollow(context.Background(), "1234567")
+	rel, err := client.AccountFollow(context.Background(), "1234567")
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
@@ -335,11 +335,11 @@ func TestAccountUnfollow(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	rel, err := client.AccountUnfollow(context.Background(), "123")
+	_, err := client.AccountUnfollow(context.Background(), "123")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	rel, err = client.AccountUnfollow(context.Background(), "1234567")
+	rel, err := client.AccountUnfollow(context.Background(), "1234567")
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}

--- a/lists_test.go
+++ b/lists_test.go
@@ -125,11 +125,11 @@ func TestGetList(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	list, err := client.GetList(context.Background(), "2")
+	_, err := client.GetList(context.Background(), "2")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	list, err = client.GetList(context.Background(), "1")
+	list, err := client.GetList(context.Background(), "1")
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
@@ -154,11 +154,11 @@ func TestCreateList(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	list, err := client.CreateList(context.Background(), "")
+	_, err := client.CreateList(context.Background(), "")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	list, err = client.CreateList(context.Background(), "foo")
+	list, err := client.CreateList(context.Background(), "foo")
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
@@ -187,11 +187,11 @@ func TestRenameList(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	list, err := client.RenameList(context.Background(), "2", "bar")
+	_, err := client.RenameList(context.Background(), "2", "bar")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	list, err = client.RenameList(context.Background(), "1", "bar")
+	list, err := client.RenameList(context.Background(), "1", "bar")
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}

--- a/report_test.go
+++ b/report_test.go
@@ -63,11 +63,11 @@ func TestReport(t *testing.T) {
 		ClientSecret: "bar",
 		AccessToken:  "zoo",
 	})
-	rp, err := client.Report(context.Background(), "121", nil, "")
+	_, err := client.Report(context.Background(), "121", nil, "")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
-	rp, err = client.Report(context.Background(), "122", nil, "")
+	rp, err := client.Report(context.Background(), "122", nil, "")
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}


### PR DESCRIPTION
There are a few instances of assigning a result and an error, but the result is not used. That variable is always used later in the test so setting := there