### PR TITLE
Add command timeline-tag to search for statuses matching the tag.

### DIFF
--- a/cmd/mstdn/cmd_timeline.go
+++ b/cmd/mstdn/cmd_timeline.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"strings"
 
 	"github.com/mattn/go-mastodon"
 	"github.com/urfave/cli"
@@ -57,6 +59,26 @@ func cmdTimelineDirect(c *cli.Context) error {
 	client := c.App.Metadata["client"].(*mastodon.Client)
 	config := c.App.Metadata["config"].(*mastodon.Config)
 	timeline, err := client.GetTimelineDirect(context.Background(), nil)
+	if err != nil {
+		return err
+	}
+	s := newScreen(config)
+	for i := len(timeline) - 1; i >= 0; i-- {
+		s.displayStatus(c.App.Writer, timeline[i])
+	}
+	return nil
+}
+
+func cmdTimelineHashtag(c *cli.Context) error {
+	if !c.Args().Present() {
+		return errors.New("arguments required")
+	}
+        local := c.Bool("local")
+	tag := strings.TrimLeft(argstr(c), "#")
+
+	client := c.App.Metadata["client"].(*mastodon.Client)
+	config := c.App.Metadata["config"].(*mastodon.Config)
+	timeline, err := client.GetTimelineHashtag(context.Background(), tag, local, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/mstdn/main.go
+++ b/cmd/mstdn/main.go
@@ -256,6 +256,17 @@ func makeApp() *cli.App {
 			Action: cmdTimelineDirect,
 		},
 		{
+			Name:   "timeline-tag",
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "local",
+					Usage: "local tags only",
+				},
+                        },
+			Usage:  "show tagged timeline",
+			Action: cmdTimelineHashtag,
+		},
+		{
 			Name:   "notification",
 			Usage:  "show notification",
 			Action: cmdNotification,


### PR DESCRIPTION
Since `search` only return the list of tags matching the search, this is helpful to actually see the statuses for a particular tag.