### PR TITLE
Adding accounts/lookup endpoint

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -70,6 +70,17 @@ func (c *Client) GetAccountCurrentUser(ctx context.Context) (*Account, error) {
 	return &account, nil
 }
 
+func (c *Client) AccountLookup(ctx context.Context, acct string) (*Account, error) {
+	var account Account
+	params := url.Values{}
+	params.Set("acct", acct)
+	err := c.doAPI(ctx, http.MethodGet, "/api/v1/accounts/lookup", params, &account, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &account, nil
+}
+
 // Profile is a struct for updating profiles.
 type Profile struct {
 	// If it is nil it will not be updated.

--- a/accounts.go
+++ b/accounts.go
@@ -70,6 +70,7 @@ func (c *Client) GetAccountCurrentUser(ctx context.Context) (*Account, error) {
 	return &account, nil
 }
 
+// AccountLookup returns the Account of specified acct uri.
 func (c *Client) AccountLookup(ctx context.Context, acct string) (*Account, error) {
 	var account Account
 	params := url.Values{}

--- a/example_test.go
+++ b/example_test.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/mattn/go-mastodon"
+	"github.com/rmrfslashbin/go-mastodon"
 )
 
 func ExampleRegisterApp() {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/mattn/go-mastodon
+module github.com/rmrfslashbin/go-mastodon
 
-go 1.16
+go 1.19
 
 require (
 	github.com/gorilla/websocket v1.5.0


### PR DESCRIPTION
This PR adds the `/api/v1/accounts/lookup` endpoint (https://docs.joinmastodon.org/methods/accounts/#lookup) via a new function `func (c *Client) AccountLookup(ctx context.Context, acct string) (*Account, error)`. Test included.