### PR TITLE
Feature: Save API JSON (briefly) if requested by client

### DIFF
--- a/mastodon.go
+++ b/mastodon.go
@@ -24,6 +24,11 @@ type Config struct {
 	AccessToken  string
 }
 
+type WriterResetter interface {
+	io.Writer
+	Reset()
+}
+
 // Client is a API client for mastodon.
 type Client struct {
 	http.Client
@@ -128,6 +133,9 @@ func (c *Client) doAPI(ctx context.Context, method string, uri string, params in
 	}
 
 	if c.JSONWriter != nil {
+		if resetter, ok := c.JSONWriter.(WriterResetter); ok {
+			resetter.Reset()
+		}
 		return json.NewDecoder(io.TeeReader(resp.Body, c.JSONWriter)).Decode(&res)
 	} else {
 		return json.NewDecoder(resp.Body).Decode(&res)

--- a/mastodon.go
+++ b/mastodon.go
@@ -24,17 +24,12 @@ type Config struct {
 	AccessToken  string
 }
 
-type WriteResetter interface {
-	io.Writer
-	Reset()
-}
-
 // Client is a API client for mastodon.
 type Client struct {
 	http.Client
 	Config     *Config
 	UserAgent  string
-	JSONWriter WriteResetter
+	JSONWriter io.Writer
 }
 
 func (c *Client) doAPI(ctx context.Context, method string, uri string, params interface{}, res interface{}, pg *Pagination) error {
@@ -133,7 +128,6 @@ func (c *Client) doAPI(ctx context.Context, method string, uri string, params in
 	}
 
 	if c.JSONWriter != nil {
-		c.JSONWriter.Reset()
 		return json.NewDecoder(io.TeeReader(resp.Body, c.JSONWriter)).Decode(&res)
 	} else {
 		return json.NewDecoder(resp.Body).Decode(&res)

--- a/mastodon.go
+++ b/mastodon.go
@@ -29,6 +29,7 @@ type Client struct {
 	http.Client
 	Config    *Config
 	UserAgent string
+	SaveJSON  bool
 	LastJSON  []byte
 }
 
@@ -127,17 +128,22 @@ func (c *Client) doAPI(ctx context.Context, method string, uri string, params in
 		}
 	}
 
-	// If we want to store the JSON received, we absolutely have to
-	// read all of it.  But we restrict ourselves to a max of 100M.
-	safer := &io.LimitedReader{resp.Body, 100 * 1_048_576}
-	c.LastJSON, err = io.ReadAll(safer)
+	if c.SaveJSON {
+		// We want to store the JSON received -> we absolutely have to
+		// read all of it.  But we restrict ourselves to a max of 100M.
+		safer := &io.LimitedReader{resp.Body, 100 * 1_048_576}
+		c.LastJSON, err = io.ReadAll(safer)
 
-	if err != nil || c.LastJSON == nil {
-		return err
+		if err != nil || c.LastJSON == nil {
+			return err
+		}
+
+		// ...which means we can't use `NewDecoder.Decode` any more.
+		return json.Unmarshal(c.LastJSON, &res)
+	} else {
+		// We don't want the JSON, just do the previous streaming decode.
+		return json.NewDecoder(resp.Body).Decode(&res)
 	}
-
-	// ...which means we can't use `NewDecoder.Decode` any more.
-	return json.Unmarshal(c.LastJSON, &res)
 }
 
 // NewClient returns a new mastodon API client.

--- a/status_test.go
+++ b/status_test.go
@@ -1,6 +1,7 @@
 package mastodon
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -52,7 +53,8 @@ func TestGetFavouritesSavedJSON(t *testing.T) {
 		AccessToken:  "zoo",
 	})
 
-	client.SaveJSON = true
+	var buf bytes.Buffer
+	client.JSONWriter = &buf
 
 	favs, err := client.GetFavourites(context.Background(), nil)
 	if err != nil {
@@ -70,7 +72,7 @@ func TestGetFavouritesSavedJSON(t *testing.T) {
 
 	// We get a trailing `\n` from the API which we need to trim
 	// off before we compare it with our literal above.
-	theirJSON := strings.TrimSpace(string(client.LastJSON))
+	theirJSON := strings.TrimSpace(string(buf.Bytes()))
 
 	if theirJSON != ourJSON {
 		t.Fatalf("want %q but %q", ourJSON, theirJSON)

--- a/status_test.go
+++ b/status_test.go
@@ -39,6 +39,70 @@ func TestGetFavourites(t *testing.T) {
 	}
 }
 
+func TestGetFavouritesSavedJSONTwice(t *testing.T) {
+	ourJSON := `[{"content": "foo"}, {"content": "bar"}]`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, ourJSON)
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:       ts.URL,
+		ClientID:     "foo",
+		ClientSecret: "bar",
+		AccessToken:  "zoo",
+	})
+
+	var buf bytes.Buffer
+	client.JSONWriter = &buf
+
+	favs, err := client.GetFavourites(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if len(favs) != 2 {
+		t.Fatalf("result should be two: %d", len(favs))
+	}
+	if favs[0].Content != "foo" {
+		t.Fatalf("want %q but %q", "foo", favs[0].Content)
+	}
+	if favs[1].Content != "bar" {
+		t.Fatalf("want %q but %q", "bar", favs[1].Content)
+	}
+
+	// We get a trailing `\n` from the API which we need to trim
+	// off before we compare it with our literal above.
+	theirJSON := strings.TrimSpace(string(buf.Bytes()))
+
+	if theirJSON != ourJSON {
+		t.Fatalf("want %q but %q", ourJSON, theirJSON)
+	}
+
+	// Now we call the API again to see if we get the same or doubled JSON.
+
+	favs, err = client.GetFavourites(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if len(favs) != 2 {
+		t.Fatalf("result should be two: %d", len(favs))
+	}
+	if favs[0].Content != "foo" {
+		t.Fatalf("want %q but %q", "foo", favs[0].Content)
+	}
+	if favs[1].Content != "bar" {
+		t.Fatalf("want %q but %q", "bar", favs[1].Content)
+	}
+
+	// We get a trailing `\n` from the API which we need to trim
+	// off before we compare it with our literal above.
+	theirJSON = strings.TrimSpace(string(buf.Bytes()))
+
+	if theirJSON != ourJSON {
+		t.Fatalf("want %q but %q", ourJSON, theirJSON)
+	}
+}
+
 func TestGetFavouritesSavedJSON(t *testing.T) {
 	ourJSON := `[{"content": "foo"}, {"content": "bar"}]`
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
I'm using this library for archival purposes (eg. saving my favourites to SQLite) and I find it useful to keep the raw API response around after the API call since it often contains extensions, fields, etc., that aren't necessarily parsed out and returned in library objects.

e.g. from my Akkoma instance, status responses have information about quote-boosting which doesn't exist in the `mastodon.Status` struct.  Also various `pleroma` and `akkoma` extensions for the status text and instance information.

Since almost no-one is going to need this, it's gated behind `Client.SaveJSON` being `true` (and limited to 100MB of JSON to be safe.)  By default, the library will behave exactly the same as before.

(I admit it's not a great solution but I don't think there is one for a situation like this without extending every API method to optionally return the JSON or similar.)