### PR TITLE
Fix ID type of report methods

### DIFF
--- a/report.go
+++ b/report.go
@@ -8,8 +8,8 @@ import (
 
 // Report holds information for a mastodon report.
 type Report struct {
-	ID          int64 `json:"id"`
-	ActionTaken bool  `json:"action_taken"`
+	ID          ID   `json:"id"`
+	ActionTaken bool `json:"action_taken"`
 }
 
 // GetReports returns report of the current user.

--- a/report_test.go
+++ b/report_test.go
@@ -31,10 +31,10 @@ func TestGetReports(t *testing.T) {
 	if len(rs) != 2 {
 		t.Fatalf("result should be two: %d", len(rs))
 	}
-	if rs[0].ID != 122 {
+	if rs[0].ID != "122" {
 		t.Fatalf("want %v but %v", 122, rs[0].ID)
 	}
-	if rs[1].ID != 123 {
+	if rs[1].ID != "123" {
 		t.Fatalf("want %v but %v", 123, rs[1].ID)
 	}
 }
@@ -71,7 +71,7 @@ func TestReport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
-	if rp.ID != 1234 {
+	if rp.ID != "1234" {
 		t.Fatalf("want %q but %q", "1234", rp.ID)
 	}
 	if rp.ActionTaken {
@@ -81,7 +81,7 @@ func TestReport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
-	if rp.ID != 1234 {
+	if rp.ID != "1234" {
 		t.Fatalf("want %q but %q", "1234", rp.ID)
 	}
 	if !rp.ActionTaken {


### PR DESCRIPTION
Creating a report currently results in a panic saying that the ID type (int64) does not match the expected type (string). This patch fixes this.
It is an API breaking change.