### PR TITLE
RFC: Fix go-mastodon authentication flows

### DIFF
--- a/examples/public-application/main.go
+++ b/examples/public-application/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/mattn/go-mastodon"
+)
+
+func main() {
+	// Register the application
+	appConfig := &mastodon.AppConfig{
+		Server:       "https://mastodon.social",
+		ClientName:   "publicApp",
+		Scopes:       "read write push",
+		Website:      "https://github.com/mattn/go-mastodon",
+		RedirectURIs: "urn:ietf:wg:oauth:2.0:oob",
+	}
+
+	app, err := mastodon.RegisterApp(context.Background(), appConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	config := &mastodon.Config{
+		Server:       "https://mastodon.social",
+		ClientID:     app.ClientID,
+		ClientSecret: app.ClientSecret,
+	}
+
+	// Create the client
+	c := mastodon.NewClient(config)
+
+	// Get an Access Token & Sets it in the client config
+	err = c.GetAppAccessToken(context.Background(), app.RedirectURI)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Save credentials for later usage if you wish to do so, config file, database, etc...
+	fmt.Println("ClientID:", c.Config.ClientID)
+	fmt.Println("ClientSecret:", c.Config.ClientSecret)
+	fmt.Println("Access Token:", c.Config.AccessToken)
+
+	// Lookup and account id
+	acc, err := c.AccountLookup(context.Background(), "coolapso")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(acc)
+
+	pager := mastodon.Pagination{
+		Limit: 10,
+	}
+
+	// Get the the usernames of users following the account ID
+	followers, err := c.GetAccountFollowers(context.Background(), acc.ID, &pager)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, f := range followers {
+		fmt.Println(f.Username)
+	}
+}

--- a/examples/user-credentials/main.go
+++ b/examples/user-credentials/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/mattn/go-mastodon"
+)
+
+// Create client with credentials from user generated application
+func main() {
+	config := &mastodon.Config{
+		Server:       "https://mastodon.social",
+		ClientID:     "ClientKey",
+		ClientSecret: "ClientSecret",
+		AccessToken:  "AccessToken",
+	}
+
+	// Create the client
+	c := mastodon.NewClient(config)
+
+	// Post a toot
+	finalText := "this is the content of my new post!"
+	visibility := "public"
+
+	toot := mastodon.Toot{
+		Status:     finalText,
+		Visibility: visibility,
+	}
+
+	post, err := c.PostStatus(context.Background(), &toot)
+	if err != nil {
+		log.Fatalf("%#v\n", err)
+	}
+
+	fmt.Println("My new post is:", post)
+}

--- a/examples/user-oauth-authorization/main.go
+++ b/examples/user-oauth-authorization/main.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+
+	"github.com/mattn/go-mastodon"
+)
+
+func ConfigureClient() {
+	appConfig := &mastodon.AppConfig{
+		Server:       "https://mastodon.social",
+		ClientName:   "publicApp",
+		Scopes:       "read write follow",
+		Website:      "https://github.com/mattn/go-mastodon",
+		RedirectURIs: "urn:ietf:wg:oauth:2.0:oob",
+	}
+
+	app, err := mastodon.RegisterApp(context.Background(), appConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Have the user manually get the token and send it back to us
+	u, err := url.Parse(app.AuthURI)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Open your browser to \n%s\n and copy/paste the given authroization code\n", u)
+	var userAuthorizationCode string
+	fmt.Print("Paste the code here:")
+	fmt.Scanln(&userAuthorizationCode)
+
+	config := &mastodon.Config{
+		Server:       "https://mastodon.social",
+		ClientID:     app.ClientID,
+		ClientSecret: app.ClientSecret,
+	}
+
+	// Create the client
+	c := mastodon.NewClient(config)
+
+	// Exchange the User authentication code with an access token, that can be used to interact with the api on behalf of the user
+	err = c.GetUserAccessToken(context.Background(), userAuthorizationCode, app.RedirectURI)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Lets Export the secrets so we can use them later to preform actions on behalf of the user
+	// Without having to request authroization all the time.
+	// Exporting this as Environment variables, but it can be a configuration file, or database, anywhere you'd like to keep this credentials
+	os.Setenv("MASTODON_CLIENT_ID", c.Config.ClientID)
+	os.Setenv("MASTODON_CLIENT_SECRET", c.Config.ClientSecret)
+	os.Setenv("MASTODON_ACCESS_TOKEN", c.Config.AccessToken)
+}
+
+// Preform user actions wihtout having to re-authenticate again
+func doUserActions() {
+	// Load Environment variables, config file, secrets from db
+	clientID := os.Getenv("MASTODON_CLIENT_ID")
+	clientSecret := os.Getenv("MASTODON_CLIENT_SECRET")
+	accessToken := os.Getenv("MASTODON_ACCESS_TOKEN")
+
+	config := &mastodon.Config{
+		Server:       "https://mastodon.social",
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		AccessToken:  accessToken,
+	}
+
+	// instanciate the new client
+	c := mastodon.NewClient(config)
+
+	// Let's do some actions on behalf of the user!
+	acct, err := c.GetAccountCurrentUser(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Account is %v\n", acct)
+
+	finalText := "this is the content of my new post!"
+	visibility := "public"
+
+	// Post a toot
+	toot := mastodon.Toot{
+		Status:     finalText,
+		Visibility: visibility,
+	}
+	post, err := c.PostStatus(context.Background(), &toot)
+
+	if err != nil {
+		log.Fatalf("%#v\n", err)
+	}
+
+	fmt.Printf("My new post is %v\n", post)
+
+}
+
+func main() {
+	ConfigureClient()
+	doUserActions()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,10 @@
 module github.com/mattn/go-mastodon
 
-go 1.21
+go 1.23
 
 require (
-	github.com/gorilla/websocket v1.5.1
+	github.com/gorilla/websocket v1.5.3
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
 )
-
-require golang.org/x/net v0.25.0 // indirect
 
 retract [v0.0.7+incompatible, v0.0.7+incompatible] // Accidental; no major changes or features.

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
-github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
-github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
-golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
-golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.21
+go 1.23
 
-toolchain go1.22.2
+toolchain go1.23.2
 
 use (
 	.

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,5 +1,10 @@
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
+golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
+golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
+golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.19.0/go.mod h1:2CuTdWZ7KHSQwUzKva0cbMg6q2DMI3Mmxp+gKJbskEk=
+golang.org/x/term v0.20.0/go.mod h1:8UkIAJTvZgivsXaD6/pH6U9ecQzZ45awqEOzuCvwpFY=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/mastodon.go
+++ b/mastodon.go
@@ -151,6 +151,8 @@ func NewClient(config *Config) *Client {
 }
 
 // Authenticate gets access-token to the API.
+// DEPRECATED: Authenticating with username and password is no longer supported, please use
+// GetAppAccessToken() or GetUserAccessToken() instead
 func (c *Client) Authenticate(ctx context.Context, username, password string) error {
 	params := url.Values{
 		"client_id":     {c.Config.ClientID},
@@ -165,6 +167,7 @@ func (c *Client) Authenticate(ctx context.Context, username, password string) er
 }
 
 // AuthenticateApp logs in using client credentials.
+// DEPRECATED: use GetAppAccessToken() instead
 func (c *Client) AuthenticateApp(ctx context.Context) error {
 	params := url.Values{
 		"client_id":     {c.Config.ClientID},
@@ -176,9 +179,22 @@ func (c *Client) AuthenticateApp(ctx context.Context) error {
 	return c.authenticate(ctx, params)
 }
 
+// GetAppAccessToken exchanges API Credentials for an application Access Token
+// https://docs.joinmastodon.org/api/oauth-tokens/#app-tokens
+func (c *Client) GetAppAccessToken(ctx context.Context, redirectURI string) error {
+	params := url.Values{
+		"client_id":     {c.Config.ClientID},
+		"client_secret": {c.Config.ClientSecret},
+		"grant_type":    {"client_credentials"},
+		"redirect_uri":  {redirectURI},
+	}
+
+	return c.getAccessToken(ctx, params)
+}
+
 // AuthenticateToken logs in using a grant token returned by Application.AuthURI.
-//
 // redirectURI should be the same as Application.RedirectURI.
+// DEPRECATED:  Use GetUserAccessToken() instead
 func (c *Client) AuthenticateToken(ctx context.Context, authCode, redirectURI string) error {
 	params := url.Values{
 		"client_id":     {c.Config.ClientID},
@@ -191,6 +207,21 @@ func (c *Client) AuthenticateToken(ctx context.Context, authCode, redirectURI st
 	return c.authenticate(ctx, params)
 }
 
+// GetUserAccessToken exhanges a user provided authorization code for an User Access Token
+// https://docs.joinmastodon.org/api/oauth-tokens/#user-tokens
+func (c *Client) GetUserAccessToken(ctx context.Context, authCode, redirectURI string) error {
+	params := url.Values{
+		"client_id":     {c.Config.ClientID},
+		"client_secret": {c.Config.ClientSecret},
+		"grant_type":    {"authorization_code"},
+		"code":          {authCode},
+		"redirect_uri":  {redirectURI},
+	}
+
+	return c.getAccessToken(ctx, params)
+}
+
+// DEPRECATED: Use getAccessToken() instead
 func (c *Client) authenticate(ctx context.Context, params url.Values) error {
 	u, err := url.Parse(c.Config.Server)
 	if err != nil {
@@ -225,6 +256,46 @@ func (c *Client) authenticate(ctx context.Context, params url.Values) error {
 		return err
 	}
 	c.Config.AccessToken = res.AccessToken
+	return nil
+}
+
+// Exchanges credentials for an access token to be used by applications and sets the access token in the client config
+func (c *Client) getAccessToken(ctx context.Context, params url.Values) error {
+	u, err := url.Parse(c.Config.Server)
+	if err != nil {
+		return err
+	}
+	u.Path = path.Join(u.Path, "/oauth/token")
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), strings.NewReader(params.Encode()))
+	if err != nil {
+		return err
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return parseAPIError("bad authorization", resp)
+	}
+
+	var res struct {
+		AccessToken string `json:"access_token"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&res)
+	if err != nil {
+		return err
+	}
+
+	c.Config.AccessToken = res.AccessToken
+
 	return nil
 }
 


### PR DESCRIPTION
at this point go-mastodon authentication is quite confusing and not aligned with the mastodon documentation, causing confusion and misunderstandings about the package usage. Existing methods are not descriptive of what exactly is happening thus making it hard to understand how credentials should be used in general, specially around the exchange between an authorization code and an access token.

This PR aims to fix https://github.com/mattn/go-mastodon/issues/194 and most likely the potential causes of https://github.com/mattn/go-mastodon/issues/154

And the purposed solution marks the existing methods as DEPRECATED and creates new ones thus avoiding breaking changes with previous versions of this package.

in the issue https://github.com/mattn/go-mastodon/issues/194 I've mentioned about returning the value of the access token, however for consistency I have decided to not do it, and opted to keep a similar approach to the original approach and instead documented how users can export the credentials for using them at a later stage. 

This pr also updates the package documentation by adding a directory with different working examples. 
Code snippets were removed from the README and instead added links to mastodon documentation and to the working examples so users can try them for themselves in a quicker way. 

Any comments or suggestions are highly appreciated. 