### PR TITLE
mastodon: add ID.Compare to sort IDs

### DIFF
--- a/compat.go
+++ b/compat.go
@@ -25,6 +25,44 @@ func (id *ID) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// Compare compares the Mastodon IDs i and j.
+// Compare returns:
+//
+//	-1 if i is less than j,
+//	 0 if i equals j,
+//	-1 if j is greater than i.
+//
+// Compare can be used as an argument of [slices.SortFunc]:
+//
+//	slices.SortFunc([]mastodon.ID{id1, id2}, mastodon.ID.Compare)
+func (i ID) Compare(j ID) int {
+	var (
+		ii = i.u64()
+		jj = j.u64()
+	)
+
+	switch {
+	case ii < jj:
+		return -1
+	case ii == jj:
+		return 0
+	case jj < ii:
+		return +1
+	}
+	panic("impossible")
+}
+
+func (i ID) u64() uint64 {
+	if i == "" {
+		return 0
+	}
+	v, err := strconv.ParseUint(string(i), 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
 type Sbool bool
 
 func (s *Sbool) UnmarshalJSON(data []byte) error {

--- a/compat.go
+++ b/compat.go
@@ -2,7 +2,6 @@ package mastodon
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 )
 
@@ -21,7 +20,7 @@ func (id *ID) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &n); err != nil {
 		return err
 	}
-	*id = ID(fmt.Sprint(n))
+	*id = ID(strconv.FormatInt(n, 10))
 	return nil
 }
 

--- a/compat_test.go
+++ b/compat_test.go
@@ -1,0 +1,34 @@
+package mastodon_test
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/mattn/go-mastodon"
+)
+
+func TestIDCompare(t *testing.T) {
+	ids := []mastodon.ID{
+		"123",
+		"103",
+		"",
+		"0",
+		"103",
+		"122",
+	}
+
+	slices.SortFunc(ids, mastodon.ID.Compare)
+	want := []mastodon.ID{
+		"",
+		"0",
+		"103",
+		"103",
+		"122",
+		"123",
+	}
+
+	if got, want := ids, want; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid sorted slices:\ngot= %q\nwant=%q", got, want)
+	}
+}


### PR DESCRIPTION
This CL adds the Compare method to ID in order to make slices of IDs
sortable (e.g. via `slices.SortFunc(ids, mastodon.ID.Compare)`)
