### PR TITLE
all: apply staticcheck fixes

### DIFF
--- a/accounts_test.go
+++ b/accounts_test.go
@@ -892,7 +892,7 @@ func TestGetFollowedTags(t *testing.T) {
 	if !followedTags[0].Following {
 		t.Fatalf("want following, but got false")
 	}
-	if 3 != len(followedTags[0].History) {
+	if len(followedTags[0].History) != 3 {
 		t.Fatalf("expecting first tag history length to be %d but got %d", 3, len(followedTags[0].History))
 	}
 	if followedTags[1].Name != "Test2" {
@@ -904,7 +904,7 @@ func TestGetFollowedTags(t *testing.T) {
 	if !followedTags[1].Following {
 		t.Fatalf("want following, but got false")
 	}
-	if 1 != len(followedTags[1].History) {
+	if len(followedTags[1].History) != 1 {
 		t.Fatalf("expecting first tag history length to be %d but got %d", 1, len(followedTags[1].History))
 	}
 }

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,7 +1,7 @@
 package mastodon
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -39,7 +39,7 @@ func TestBase64Encode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
-	_, err = ioutil.ReadAll(logo)
+	_, err = io.ReadAll(logo)
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestString(t *testing.T) {
 
 func TestParseAPIError(t *testing.T) {
 	// No api error.
-	r := ioutil.NopCloser(strings.NewReader(`<html><head><title>404</title></head></html>`))
+	r := io.NopCloser(strings.NewReader(`<html><head><title>404</title></head></html>`))
 	err := parseAPIError("bad request", &http.Response{
 		Status:     "404 Not Found",
 		StatusCode: http.StatusNotFound,
@@ -84,7 +84,7 @@ func TestParseAPIError(t *testing.T) {
 	}
 
 	// With api error.
-	r = ioutil.NopCloser(strings.NewReader(`{"error":"Record not found"}`))
+	r = io.NopCloser(strings.NewReader(`{"error":"Record not found"}`))
 	err = parseAPIError("bad request", &http.Response{
 		Status:     "404 Not Found",
 		StatusCode: http.StatusNotFound,

--- a/status_test.go
+++ b/status_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -878,7 +877,7 @@ func TestUploadMedia(t *testing.T) {
 	if writerAttachment.ID != "123" {
 		t.Fatalf("want %q but %q", "123", attachment.ID)
 	}
-	bytes, err := ioutil.ReadFile("testdata/logo.png")
+	bytes, err := os.ReadFile("testdata/logo.png")
 	if err != nil {
 		t.Fatalf("could not open file: %v", err)
 	}

--- a/status_test.go
+++ b/status_test.go
@@ -72,7 +72,7 @@ func TestGetFavouritesSavedJSONTwice(t *testing.T) {
 
 	// We get a trailing `\n` from the API which we need to trim
 	// off before we compare it with our literal above.
-	theirJSON := strings.TrimSpace(string(buf.Bytes()))
+	theirJSON := strings.TrimSpace(buf.String())
 
 	if theirJSON != ourJSON {
 		t.Fatalf("want %q but %q", ourJSON, theirJSON)
@@ -96,7 +96,7 @@ func TestGetFavouritesSavedJSONTwice(t *testing.T) {
 
 	// We get a trailing `\n` from the API which we need to trim
 	// off before we compare it with our literal above.
-	theirJSON = strings.TrimSpace(string(buf.Bytes()))
+	theirJSON = strings.TrimSpace(buf.String())
 
 	if theirJSON != ourJSON {
 		t.Fatalf("want %q but %q", ourJSON, theirJSON)
@@ -136,7 +136,7 @@ func TestGetFavouritesSavedJSON(t *testing.T) {
 
 	// We get a trailing `\n` from the API which we need to trim
 	// off before we compare it with our literal above.
-	theirJSON := strings.TrimSpace(string(buf.Bytes()))
+	theirJSON := strings.TrimSpace(buf.String())
 
 	if theirJSON != ourJSON {
 		t.Fatalf("want %q but %q", ourJSON, theirJSON)


### PR DESCRIPTION
- all: remove use of deprecated io/ioutil package
- all: use crypto/ecdh.PublicKey in lieu of deprecated crypto/elliptic.Marshal
- use `buf.String()` instead of `string(buf.Bytes())`