### PR TITLE
Image Upload Fix and struct Field enhancement

### DIFF
--- a/mastodon.go
+++ b/mastodon.go
@@ -359,13 +359,15 @@ type Attachment struct {
 	PreviewURL  string         `json:"preview_url"`
 	TextURL     string         `json:"text_url"`
 	Description string         `json:"description"`
+	BlurHash    string         `json:"blurhash"`
 	Meta        AttachmentMeta `json:"meta"`
 }
 
 // AttachmentMeta holds information for attachment metadata.
 type AttachmentMeta struct {
-	Original AttachmentSize `json:"original"`
-	Small    AttachmentSize `json:"small"`
+	Original AttachmentSize  `json:"original"`
+	Small    AttachmentSize  `json:"small"`
+	Focus    AttachmentFocus `json:"focus"`
 }
 
 // AttachmentSize holds information for attatchment size.
@@ -374,6 +376,12 @@ type AttachmentSize struct {
 	Height int64   `json:"height"`
 	Size   string  `json:"size"`
 	Aspect float64 `json:"aspect"`
+}
+
+// AttachmentSize holds information for attatchment size.
+type AttachmentFocus struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
 }
 
 // Emoji hold information for CustomEmoji.

--- a/mastodon.go
+++ b/mastodon.go
@@ -118,7 +118,7 @@ func (c *Client) doAPI(ctx context.Context, method string, uri string, params in
 		break
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		return parseAPIError("bad request", resp)
 	} else if res == nil {
 		return nil

--- a/status.go
+++ b/status.go
@@ -496,7 +496,8 @@ func (c *Client) UploadMediaFromReader(ctx context.Context, reader io.Reader) (*
 // UploadMediaFromMedia uploads a media attachment from a Media struct.
 func (c *Client) UploadMediaFromMedia(ctx context.Context, media *Media) (*Attachment, error) {
 	var attachment Attachment
-	if err := c.doAPI(ctx, http.MethodPost, "/api/v1/media", media, &attachment, nil); err != nil {
+	// "/api/v2/media" USING V2 TODO: IMPORTANT
+	if err := c.doAPI(ctx, http.MethodPost, "/api/v2/media", media, &attachment, nil); err != nil {
 		return nil, err
 	}
 	return &attachment, nil


### PR DESCRIPTION
Hi,

in order to upload images to newer Mastodon instances, the v2 api endpoint needs to be used.
I cherry-picked the patch from wakumaku and confirmed that this works.

I also added http.StatusAccepted 202 as valid return code. See [Specs](https://docs.joinmastodon.org/methods/media/#202-accepted). Should not impact any other functionality, but please check.

While I was at it, I added the new ImageAttachement fields, in case someone needs them.

