### PR TITLE
mastodon: add iter.Seq API

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"iter"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -175,6 +176,33 @@ func (c *Client) AccountUpdate(ctx context.Context, profile *Profile) (*Account,
 		return nil, err
 	}
 	return &account, nil
+}
+
+// AccountStatuses iterates over statuses for the provided account id.
+func (c *Client) AccountStatuses(ctx context.Context, id ID, pg *Pagination) iter.Seq2[*Status, error] {
+	return func(yield func(*Status, error) bool) {
+		var zero Pagination
+		if pg == nil {
+			pg = &Pagination{}
+		}
+		for {
+			vs, err := c.GetAccountStatuses(ctx, id, pg)
+			if err != nil {
+				_ = yield(nil, err)
+				return
+			}
+
+			for _, v := range vs {
+				if !yield(v, nil) {
+					return
+				}
+			}
+
+			if *pg == zero {
+				return
+			}
+		}
+	}
 }
 
 // GetAccountStatuses return statuses by specified account.

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -2,9 +2,11 @@ package mastodon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -142,6 +144,120 @@ func TestAccountUpdate(t *testing.T) {
 	}
 	if a.Username != "zzz" {
 		t.Fatalf("want %q but %q", "zzz", a.Username)
+	}
+}
+
+func TestAccountStatuses(t *testing.T) {
+	type statusT struct {
+		Content string `json:"content"`
+	}
+	slice := []statusT{
+		{"0"}, {"1"}, {"2"}, {"3"}, {"4"},
+		{"5"}, {"6"}, {"7"}, {"8"}, {"9"},
+	}
+
+	var (
+		limit = 1
+		cur   int
+		end   int
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/accounts/1234567/statuses" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		var (
+			err  error
+			qry  = r.URL.Query()
+			qmin = qry.Get("min_id")
+			qmax = qry.Get("max_id")
+			qlim = qry.Get("limit")
+		)
+
+		switch qmin {
+		case "":
+			limit = 1
+			cur = 0
+			end = cur + limit
+		}
+
+		switch {
+		case qlim != "":
+			limit, err = strconv.Atoi(qlim)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			end = min(cur+limit, len(slice))
+		case qmax != "":
+			vmax, err := strconv.Atoi(qmax)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			end = min(vmax, len(slice))
+		}
+
+		vs := slice[cur:end]
+		switch {
+		case end >= len(slice):
+			w.Header().Set("Link", ``)
+		default:
+			var (
+				nextMin = end
+				nextMax = end + limit
+			)
+			w.Header().Set(
+				"Link",
+				fmt.Sprintf(
+					`<http://example.com?min_id=%d&max_id=%d&since_id=%d&limit=%d>; rel="next"`,
+					nextMin, nextMax, nextMin, limit,
+				),
+			)
+		}
+
+		err = json.NewEncoder(w).Encode(vs)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		cur = end
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:       ts.URL,
+		ClientID:     "foo",
+		ClientSecret: "bar",
+		AccessToken:  "zoo",
+	})
+
+	ctx := context.Background()
+	for _, err := range client.AccountStatuses(ctx, "123", nil) {
+		if err == nil {
+			t.Fatal("expected iteration to fail")
+		}
+	}
+
+	var vs []*Status
+	for v, err := range client.AccountStatuses(ctx, "1234567", &Pagination{Limit: 3}) {
+		if err != nil {
+			t.Fatalf("could not iterate over statuses: %v", err)
+		}
+		vs = append(vs, v)
+		if len(vs) > len(slice) {
+			t.Fatal("boo")
+		}
+	}
+
+	if got, want := len(vs), len(slice); got != want {
+		t.Fatalf("invalid number of statuses: got=%d, want=%d", got, want)
+	}
+
+	for i, want := range slice {
+		if got, want := vs[i].Content, want.Content; got != want {
+			t.Fatalf("invalid status[%d] content: got=%q, want=%q", i, got, want)
+		}
 	}
 }
 

--- a/mastodon.go
+++ b/mastodon.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -123,12 +124,15 @@ func (c *Client) doAPI(ctx context.Context, method string, uri string, params in
 	} else if res == nil {
 		return nil
 	} else if pg != nil {
-		if lh := resp.Header.Get("Link"); lh != "" {
-			pg2, err := newPagination(lh)
+		switch lh := resp.Header.Get("Link"); lh {
+		case "":
+			*pg = Pagination{}
+		default:
+			_, next, err := newPaginationPrevNext(lh)
 			if err != nil {
 				return err
 			}
-			*pg = *pg2
+			*pg = next
 		}
 	}
 
@@ -407,33 +411,39 @@ type Pagination struct {
 	Limit   int64
 }
 
-func newPagination(rawlink string) (*Pagination, error) {
+func newPaginationPrevNext(rawlink string) (prev, next Pagination, err error) {
 	if rawlink == "" {
-		return nil, errors.New("empty link header")
+		return prev, next, errors.New("empty link header")
 	}
 
-	p := &Pagination{}
 	for _, link := range linkheader.Parse(rawlink) {
 		switch link.Rel {
 		case "next":
-			maxID, err := getPaginationID(link.URL, "max_id")
+			next, err = paginationFromLink(link.URL)
 			if err != nil {
-				return nil, err
+				return prev, next, err
 			}
-			p.MaxID = maxID
-		case "prev":
-			sinceID, err := getPaginationID(link.URL, "since_id")
-			if err != nil {
-				return nil, err
-			}
-			p.SinceID = sinceID
 
-			minID, err := getPaginationID(link.URL, "min_id")
+		case "prev":
+			prev, err = paginationFromLink(link.URL)
 			if err != nil {
-				return nil, err
+				return prev, next, err
 			}
-			p.MinID = minID
 		}
+	}
+
+	return
+}
+
+func paginationFromLink(link string) (p Pagination, err error) {
+	uri, err := url.Parse(link)
+	if err != nil {
+		return p, err
+	}
+
+	err = p.fromValues(uri.Query())
+	if err != nil {
+		return p, err
 	}
 
 	return p, nil
@@ -446,6 +456,24 @@ func getPaginationID(rawurl, key string) (ID, error) {
 	}
 
 	return ID(u.Query().Get(key)), nil
+}
+
+func (p *Pagination) fromValues(vs url.Values) error {
+	p.MaxID = ID(vs.Get("max_id"))
+	p.MinID = ID(vs.Get("min_id"))
+	p.SinceID = ID(vs.Get("since_id"))
+
+	switch v := vs.Get("limit"); v {
+	case "":
+		p.Limit = 0
+	default:
+		limit, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return fmt.Errorf("could not parse 'limit' query: %w", err)
+		}
+		p.Limit = limit
+	}
+	return nil
 }
 
 func (p *Pagination) toValues() url.Values {

--- a/mastodon_test.go
+++ b/mastodon_test.go
@@ -45,11 +45,11 @@ func TestDoAPI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
-	if pg.MaxID != "234" {
-		t.Fatalf("want %q but %q", "234", pg.MaxID)
+	if got, want := pg.MaxID, ID("234"); got != want {
+		t.Fatalf("want %q but %q", want, got)
 	}
-	if pg.SinceID != "890" {
-		t.Fatalf("want %q but %q", "890", pg.SinceID)
+	if got, want := pg.SinceID, ID(""); got != want {
+		t.Fatalf("want %q but %q", want, got)
 	}
 	if accounts[0].Username != "foo" {
 		t.Fatalf("want %q but %q", "foo", accounts[0].Username)
@@ -67,11 +67,11 @@ func TestDoAPI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
-	if pg.MaxID != "234" {
-		t.Fatalf("want %q but %q", "234", pg.MaxID)
+	if got, want := pg.MaxID, ID("234"); got != want {
+		t.Fatalf("want %q but %q", want, got)
 	}
-	if pg.SinceID != "890" {
-		t.Fatalf("want %q but %q", "890", pg.SinceID)
+	if got, want := pg.SinceID, ID(""); got != want {
+		t.Fatalf("want %q but %q", want, got)
 	}
 	if accounts[0].Username != "foo" {
 		t.Fatalf("want %q but %q", "foo", accounts[0].Username)
@@ -686,35 +686,35 @@ func TestForTheCoverages(t *testing.T) {
 }
 
 func TestNewPagination(t *testing.T) {
-	_, err := newPagination("")
+	_, _, err := newPaginationPrevNext("")
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
 
-	_, err = newPagination(`<:>; rel="next"`)
+	_, _, err = newPaginationPrevNext(`<:>; rel="next"`)
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
 
-	_, err = newPagination(`<:>; rel="prev"`)
+	_, _, err = newPaginationPrevNext(`<:>; rel="prev"`)
 	if err == nil {
 		t.Fatalf("should be fail: %v", err)
 	}
 
-	_, err = newPagination(`<http://example.com?min_id=abc>; rel="prev"`)
+	_, _, err = newPaginationPrevNext(`<http://example.com?min_id=abc>; rel="prev"`)
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
 
-	pg, err := newPagination(`<http://example.com?max_id=123>; rel="next", <http://example.com?since_id=789>; rel="prev"`)
+	prev, next, err := newPaginationPrevNext(`<http://example.com?max_id=123>; rel="next", <http://example.com?since_id=789>; rel="prev"`)
 	if err != nil {
 		t.Fatalf("should not be fail: %v", err)
 	}
-	if pg.MaxID != "123" {
-		t.Fatalf("want %q but %q", "123", pg.MaxID)
+	if next.MaxID != "123" {
+		t.Fatalf("want %q but %q", "123", next.MaxID)
 	}
-	if pg.SinceID != "789" {
-		t.Fatalf("want %q but %q", "789", pg.SinceID)
+	if prev.SinceID != "789" {
+		t.Fatalf("want %q but %q", "789", prev.SinceID)
 	}
 }
 

--- a/notification.go
+++ b/notification.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/base64"
 	"fmt"
+	"iter"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -34,17 +35,69 @@ type PushAlerts struct {
 	Mention   *Sbool `json:"mention"`
 }
 
+// NotificationFilter customizes how a notification query is submitted to
+// the remote Mastodon server.
+// See:
+//
+//	https://docs.joinmastodon.org/methods/notifications/
+type NotificationFilter struct {
+	Includes []string // list of notifications types to include
+	Excludes []string // list of notifications types to exclude
+}
+
+// Notifications iterate over notifications.
+func (c *Client) Notifications(ctx context.Context, filter *NotificationFilter, pg *Pagination) iter.Seq2[*Notification, error] {
+	return c.notificationsFilter(ctx, filter, pg)
+}
+
+func (c *Client) notificationsFilter(ctx context.Context, qry *NotificationFilter, pg *Pagination) iter.Seq2[*Notification, error] {
+	return func(yield func(*Notification, error) bool) {
+		var zero Pagination
+		if pg == nil {
+			pg = &Pagination{}
+		}
+		for {
+			vs, err := c.getNotificationsFilter(ctx, qry, pg)
+			if err != nil {
+				_ = yield(nil, err)
+				return
+			}
+
+			for _, v := range vs {
+				if !yield(v, nil) {
+					return
+				}
+			}
+
+			if *pg == zero {
+				return
+			}
+		}
+	}
+}
+
 // GetNotifications returns notifications.
 func (c *Client) GetNotifications(ctx context.Context, pg *Pagination) ([]*Notification, error) {
-	return c.GetNotificationsExclude(ctx, nil, pg)
+	return c.getNotificationsFilter(ctx, nil, pg)
 }
 
 // GetNotificationsExclude returns notifications with excluded notifications
 func (c *Client) GetNotificationsExclude(ctx context.Context, exclude *[]string, pg *Pagination) ([]*Notification, error) {
+	qry := &NotificationFilter{}
+	if exclude != nil {
+		qry.Excludes = *exclude
+	}
+	return c.getNotificationsFilter(ctx, qry, pg)
+}
+
+func (c *Client) getNotificationsFilter(ctx context.Context, qry *NotificationFilter, pg *Pagination) ([]*Notification, error) {
 	var notifications []*Notification
 	params := url.Values{}
-	if exclude != nil {
-		for _, ex := range *exclude {
+	if qry != nil {
+		for _, typ := range qry.Includes {
+			params.Add("types[]", typ)
+		}
+		for _, ex := range qry.Excludes {
 			params.Add("exclude_types[]", ex)
 		}
 	}

--- a/notification_test.go
+++ b/notification_test.go
@@ -11,6 +11,93 @@ import (
 	"testing"
 )
 
+func TestNotifications(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/notifications":
+			if r.URL.Query().Get("exclude_types[]") == "follow" {
+				fmt.Fprintln(w, `[{"id": 321, "action_taken": true}]`)
+			} else {
+				fmt.Fprintln(w, `[{"id": 122, "action_taken": false}, {"id": 123, "action_taken": true}]`)
+			}
+			return
+		case "/api/v1/notifications/123":
+			fmt.Fprintln(w, `{"id": 123, "action_taken": true}`)
+			return
+		case "/api/v1/notifications/clear":
+			fmt.Fprintln(w, `{}`)
+			return
+		case "/api/v1/notifications/123/dismiss":
+			fmt.Fprintln(w, `{}`)
+			return
+		}
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:       ts.URL,
+		ClientID:     "foo",
+		ClientSecret: "bar",
+		AccessToken:  "zoo",
+	})
+
+	var (
+		ns  []*Notification
+		ctx = context.Background()
+	)
+	for n, err := range client.Notifications(ctx, nil, nil) {
+		if err != nil {
+			t.Fatalf("could not iterate over notifications: %v", err)
+		}
+		ns = append(ns, n)
+	}
+
+	if len(ns) != 2 {
+		t.Fatalf("result should be two: %d", len(ns))
+	}
+	if ns[0].ID != "122" {
+		t.Fatalf("want %v but %v", "122", ns[0].ID)
+	}
+	if ns[1].ID != "123" {
+		t.Fatalf("want %v but %v", "123", ns[1].ID)
+	}
+
+	var (
+		nse []*Notification
+		qry = &NotificationFilter{
+			Excludes: []string{"follow"},
+		}
+	)
+	for ne, err := range client.Notifications(ctx, qry, nil) {
+		if err != nil {
+			t.Fatalf("should not be fail: %v", err)
+		}
+		nse = append(nse, ne)
+	}
+	if len(nse) != 1 {
+		t.Fatalf("result should be one: %d", len(nse))
+	}
+	if nse[0].ID != "321" {
+		t.Fatalf("want %v but %v", "321", nse[0].ID)
+	}
+	n, err := client.GetNotification(context.Background(), "123")
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if n.ID != "123" {
+		t.Fatalf("want %v but %v", "123", n.ID)
+	}
+	err = client.ClearNotifications(context.Background())
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	err = client.DismissNotification(context.Background(), "123")
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+}
+
 func TestGetNotifications(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {


### PR DESCRIPTION
Fixes #161.

This CL properly handle pagination by separating the parsing of next/prev `Link` headers.
A zero-pagination value marks the end of pages.

This CL adds two examples of a `iter`-based APIs, simplifying the pagination handling in user code.