### PR TITLE
Fix upload test to match v2 media endpoint

### DIFF
--- a/cmd/mstdn/cmd_upload_test.go
+++ b/cmd/mstdn/cmd_upload_test.go
@@ -13,7 +13,7 @@ func TestCmdUpload(t *testing.T) {
 	out := testWithServer(
 		func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
-			case "/api/v1/media":
+			case "/api/v2/media":
 				fmt.Fprintln(w, `{"id": 123}`)
 				return
 			}


### PR DESCRIPTION
UploadMedia switched to POST /api/v2/media, but TestCmdUpload in cmd/mstdn still mocked /api/v1/media, so the upload failed with 404 and the test failed. Update the mock to the v2 endpoint.

Note: this module is not covered by CI's `go test ./...` at the repo root, which is why the failure went unnoticed.