### PR TITLE
Fix GetMediaStatus to use attachment ID as string

### DIFF
--- a/status.go
+++ b/status.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -549,7 +548,7 @@ func (c *Client) UploadMediaFromMedia(ctx context.Context, media *Media) (*Attac
 
 // GetMediaStatus checks the status of a media attachment.
 func (c *Client) GetMediaStatus(ctx context.Context, attachment *Attachment) error {
-	return c.doAPI(ctx, http.MethodGet, "/api/v1/media/"+strconv.Itoa(int(attachment.ID.u64())), nil, nil, nil)
+	return c.doAPI(ctx, http.MethodGet, "/api/v1/media/"+url.PathEscape(string(attachment.ID)), nil, nil, nil)
 }
 
 // GetTimelineDirect return statuses from direct timeline.

--- a/status_test.go
+++ b/status_test.go
@@ -1050,6 +1050,28 @@ func TestUploadMedia(t *testing.T) {
 
 }
 
+func TestGetMediaStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Mastodon IDs are opaque strings; other implementations use
+		// non-numeric IDs such as ULIDs.
+		if r.URL.Path == "/api/v1/media/01F8MH5ZYAS9XKD4NK1FSD5J1Z" {
+			fmt.Fprintln(w, `{"id": "01F8MH5ZYAS9XKD4NK1FSD5J1Z", "type": "image"}`)
+			return
+		}
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:      ts.URL,
+		AccessToken: "zoo",
+	})
+	err := client.GetMediaStatus(context.Background(), &Attachment{ID: "01F8MH5ZYAS9XKD4NK1FSD5J1Z"})
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+}
+
 func TestGetConversations(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/conversations" {


### PR DESCRIPTION
GetMediaStatus converted the attachment ID via `strconv.Itoa(int(attachment.ID.u64()))`, which panics on non-numeric IDs (GoToSocial ULIDs, Pleroma flake IDs) and truncates snowflake IDs above 2^31 on 32-bit platforms, producing requests for a wrong media ID. Use the ID string directly.