### PR TITLE
Fix list stream parameter in WebSocket streaming

### DIFF
--- a/streaming_ws.go
+++ b/streaming_ws.go
@@ -66,7 +66,11 @@ func (c *WSClient) streamingWS(ctx context.Context, stream, tag string) (chan Ev
 	params.Set("access_token", c.client.Config.AccessToken)
 	params.Set("stream", stream)
 	if tag != "" {
-		params.Set("tag", tag)
+		if stream == "list" {
+			params.Set("list", tag)
+		} else {
+			params.Set("tag", tag)
+		}
 	}
 
 	u, err := changeWebSocketScheme(c.client.Config.Server)

--- a/streaming_ws_test.go
+++ b/streaming_ws_test.go
@@ -60,7 +60,13 @@ func TestStreamingWSHashtag(t *testing.T) {
 }
 
 func TestStreamingWSList(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(wsMock))
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("list") != "123" {
+			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			return
+		}
+		wsMock(w, r)
+	}))
 	defer ts.Close()
 
 	client := NewClient(&Config{Server: ts.URL}).NewWSClient()


### PR DESCRIPTION
StreamingWSList sent the list ID as `tag=<id>`, but the streaming API expects `list=<id>` when `stream=list`, so list streams over WebSocket never delivered events. The SSE counterpart already uses the correct parameter. The test now asserts the query parameter.