### PR TITLE
Fix double URL encoding of hashtag path segments

### DIFF
--- a/mastodon.go
+++ b/mastodon.go
@@ -43,7 +43,9 @@ func (c *Client) doAPI(ctx context.Context, method string, uri string, params in
 	if err != nil {
 		return err
 	}
-	u.Path = path.Join(u.Path, uri)
+	// uri may contain percent-encoded path segments (e.g. hashtags); JoinPath
+	// keeps them intact instead of escaping the percent signs again.
+	u = u.JoinPath(uri)
 
 	var req *http.Request
 	ct := "application/x-www-form-urlencoded"

--- a/status_test.go
+++ b/status_test.go
@@ -810,6 +810,30 @@ func TestGetTimelineHashtagMultiple(t *testing.T) {
 	}
 }
 
+func TestGetTimelineHashtagUnicode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The tag must arrive percent-encoded exactly once.
+		if r.URL.Path != "/api/v1/timelines/tag/日本語" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		fmt.Fprintln(w, `[{"content": "zzz"}]`)
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:      ts.URL,
+		AccessToken: "zoo",
+	})
+	tags, err := client.GetTimelineHashtag(context.Background(), "日本語", false, nil)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if len(tags) != 1 {
+		t.Fatalf("should have %d entries but %d", 1, len(tags))
+	}
+}
+
 func TestGetTimelineHashtag(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/timelines/tag/zzz" {

--- a/tags.go
+++ b/tags.go
@@ -30,7 +30,7 @@ func (c *Client) TagFollow(ctx context.Context, tag string) (*FollowedTag, error
 // TagUnfollow unfollows a hashtag.
 func (c *Client) TagUnfollow(ctx context.Context, ID string) (*FollowedTag, error) {
 	var tag FollowedTag
-	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/tags/%s/unfollow", ID), nil, &tag, nil)
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/tags/%s/unfollow", url.PathEscape(ID)), nil, &tag, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
doAPI assigned the request path (already percent-encoded by callers via url.PathEscape) to u.Path, which holds the decoded form, so URL.String() escaped the percent signs again. Any non-ASCII hashtag (e.g. Japanese tags) reached the server double-encoded and hit the wrong endpoint: GetTimelineHashtag, TagInfo and TagFollow were all affected.

Use URL.JoinPath, which keeps percent-encoded segments intact, and escape the tag in TagUnfollow for consistency with TagInfo/TagFollow.