### PR TITLE
Fix ID unmarshaling of JSON null

### DIFF
--- a/compat.go
+++ b/compat.go
@@ -8,6 +8,10 @@ import (
 type ID string
 
 func (id *ID) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*id = ""
+		return nil
+	}
 	if len(data) > 0 && data[0] == '"' && data[len(data)-1] == '"' {
 		var s string
 		if err := json.Unmarshal(data, &s); err != nil {

--- a/compat_test.go
+++ b/compat_test.go
@@ -1,12 +1,33 @@
 package mastodon_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"slices"
 	"testing"
 
 	"github.com/mattn/go-mastodon"
 )
+
+func TestIDUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		in   string
+		want mastodon.ID
+	}{
+		{`"123"`, "123"},
+		{`123`, "123"},
+		{`null`, ""},
+	}
+	for _, test := range tests {
+		var id mastodon.ID
+		if err := json.Unmarshal([]byte(test.in), &id); err != nil {
+			t.Fatalf("should not be fail: %v", err)
+		}
+		if id != test.want {
+			t.Fatalf("want %q but %q for input %s", test.want, id, test.in)
+		}
+	}
+}
 
 func TestIDCompare(t *testing.T) {
 	ids := []mastodon.ID{


### PR DESCRIPTION
encoding/json calls custom unmarshalers for JSON null, and ID.UnmarshalJSON fell through to the numeric branch, where unmarshaling null into int64 is a no-op. Any nullable ID field therefore decoded as "0" instead of staying empty, breaking comparisons against "" and potentially sending "0" back to the API as a real ID.