### PR TITLE
Fix WebSocket connection leak on reconnect

### DIFF
--- a/streaming_ws.go
+++ b/streaming_ws.go
@@ -103,10 +103,17 @@ func (c *WSClient) handleWS(ctx context.Context, rawurl string, q chan Event) er
 		return err
 	}
 
+	defer conn.Close()
+
 	// Close the WebSocket when the context is canceled.
+	done := make(chan struct{})
+	defer close(done)
 	go func() {
-		<-ctx.Done()
-		conn.Close()
+		select {
+		case <-ctx.Done():
+			conn.Close()
+		case <-done:
+		}
 	}()
 
 	for {

--- a/streaming_ws_test.go
+++ b/streaming_ws_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -283,6 +284,52 @@ func TestHandleWS(t *testing.T) {
 	client.handleWS(context.Background(), "ws://"+ts.Listener.Addr().String(), q)
 
 	wg.Wait()
+}
+
+func TestHandleWSClosesConnOnReconnect(t *testing.T) {
+	connClosed := make(chan struct{})
+	var first atomic.Bool
+	first.Store(true)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := websocket.Upgrader{}
+		conn, err := u.Upgrade(w, r, nil)
+		if err != nil {
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+		defer conn.Close()
+
+		if first.Swap(false) {
+			// Force a read error on the client so it reconnects, then
+			// wait until the client closes this connection.
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(`<html></html>`)); err != nil {
+				return
+			}
+			conn.ReadMessage()
+			close(connClosed)
+			return
+		}
+		time.Sleep(10 * time.Second)
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{Server: ts.URL}).NewWSClient()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	q, err := client.StreamingWSDirect(ctx)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	go func() {
+		for range q {
+		}
+	}()
+
+	select {
+	case <-connClosed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("client did not close the connection before reconnecting")
+	}
 }
 
 func TestDialRedirect(t *testing.T) {


### PR DESCRIPTION
handleWS never closed the connection when ReadJSON failed; it returned and streamingWS immediately reconnected. The only closer was a per-connection goroutine blocking on ctx.Done(), so every disconnect/reconnect cycle leaked one file descriptor and one goroutine until the whole context was cancelled — long-running bots on flaky connections eventually exhaust file descriptors.

Close the connection with defer and let the context watcher goroutine exit when the handler returns.