### PR TITLE
Fix panic in ID.Compare on non-numeric IDs

### DIFF
--- a/compat.go
+++ b/compat.go
@@ -3,6 +3,7 @@ package mastodon
 import (
 	"encoding/json"
 	"strconv"
+	"strings"
 )
 
 type ID string
@@ -33,37 +34,24 @@ func (id *ID) UnmarshalJSON(data []byte) error {
 //
 //	-1 if i is less than j,
 //	 0 if i equals j,
-//	-1 if j is greater than i.
+//	+1 if i is greater than j.
+//
+// Shorter IDs sort before longer ones and IDs of the same length are
+// compared lexicographically. This matches the numeric order of the
+// integer IDs used by Mastodon while also supporting non-numeric IDs
+// (e.g. ULIDs) used by other implementations.
 //
 // Compare can be used as an argument of [slices.SortFunc]:
 //
 //	slices.SortFunc([]mastodon.ID{id1, id2}, mastodon.ID.Compare)
 func (i ID) Compare(j ID) int {
-	var (
-		ii = i.u64()
-		jj = j.u64()
-	)
-
-	switch {
-	case ii < jj:
-		return -1
-	case ii == jj:
-		return 0
-	case jj < ii:
+	if len(i) != len(j) {
+		if len(i) < len(j) {
+			return -1
+		}
 		return +1
 	}
-	panic("impossible")
-}
-
-func (i ID) u64() uint64 {
-	if i == "" {
-		return 0
-	}
-	v, err := strconv.ParseUint(string(i), 10, 64)
-	if err != nil {
-		panic(err)
-	}
-	return v
+	return strings.Compare(string(i), string(j))
 }
 
 type Sbool bool

--- a/compat_test.go
+++ b/compat_test.go
@@ -53,3 +53,23 @@ func TestIDCompare(t *testing.T) {
 		t.Fatalf("invalid sorted slices:\ngot= %q\nwant=%q", got, want)
 	}
 }
+
+func TestIDCompareNonNumeric(t *testing.T) {
+	// Non-numeric IDs (e.g. ULIDs used by GoToSocial) must not panic.
+	ids := []mastodon.ID{
+		"01F8MH5ZYAS9XKD4NK1FSD5J1Z",
+		"01F8MH0BBE73B7VKDGZRE2M3XM",
+		"123",
+	}
+
+	slices.SortFunc(ids, mastodon.ID.Compare)
+	want := []mastodon.ID{
+		"123",
+		"01F8MH0BBE73B7VKDGZRE2M3XM",
+		"01F8MH5ZYAS9XKD4NK1FSD5J1Z",
+	}
+
+	if got, want := ids, want; !reflect.DeepEqual(got, want) {
+		t.Fatalf("invalid sorted slices:\ngot= %q\nwant=%q", got, want)
+	}
+}


### PR DESCRIPTION
ID.Compare parsed both IDs with strconv.ParseUint and panicked on failure. Mastodon defines IDs as opaque strings, and other implementations return non-numeric IDs (GoToSocial ULIDs, Pleroma flake IDs), so sorting with slices.SortFunc(ids, mastodon.ID.Compare) crashed the program.

Compare by length first and lexicographically within the same length, which matches numeric order for Mastodon's canonical integer IDs (no leading zeros) and is panic-free for the rest. Also fixes the doc comment for the +1 case.