### PR TITLE
Fix short read in Base64Encode

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 )
@@ -42,7 +43,7 @@ func Base64Encode(file *os.File) (string, error) {
 	}
 
 	d := make([]byte, fi.Size())
-	_, err = file.Read(d)
+	_, err = io.ReadFull(file, d)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Base64Encode assumed a single file.Read call fills the whole buffer. Read may return fewer bytes than requested, in which case the remainder of the buffer stayed zeroed and was silently encoded into the data URI, producing corrupt output with no error. Use io.ReadFull.