### PR TITLE
Fix nil statuses returned from GetTimelineDirect

### DIFF
--- a/status.go
+++ b/status.go
@@ -564,8 +564,10 @@ func (c *Client) GetTimelineDirect(ctx context.Context, pg *Pagination) ([]*Stat
 	var statuses = []*Status{}
 
 	for _, c := range conversations {
-		s := c.LastStatus
-		statuses = append(statuses, s)
+		// LastStatus is nullable, e.g. when the last status was deleted.
+		if c.LastStatus != nil {
+			statuses = append(statuses, c.LastStatus)
+		}
 	}
 
 	return statuses, nil

--- a/status_test.go
+++ b/status_test.go
@@ -743,7 +743,7 @@ func TestGetTimelinePublic(t *testing.T) {
 
 func TestGetTimelineDirect(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, `[{"id": "4", "unread":false, "last_status" : {"content": "zzz"}}, {"id": "3", "unread":true, "last_status" : {"content": "bar"}}]`)
+		fmt.Fprintln(w, `[{"id": "4", "unread":false, "last_status" : {"content": "zzz"}}, {"id": "3", "unread":true, "last_status" : {"content": "bar"}}, {"id": "2", "unread":false, "last_status" : null}]`)
 	}))
 	defer ts.Close()
 


### PR DESCRIPTION
Conversation.last_status is nullable (e.g. when the last status in a conversation was deleted), and GetTimelineDirect appended it unconditionally, so callers iterating the returned slice hit nil pointer dereferences. Skip conversations without a last status.