### PR TITLE
Fix infinite redirect loop in WebSocket dial

### DIFF
--- a/streaming_ws.go
+++ b/streaming_ws.go
@@ -3,6 +3,7 @@ package mastodon
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"path"
@@ -177,7 +178,7 @@ func (c *WSClient) handleWS(ctx context.Context, rawurl string, q chan Event) er
 }
 
 func (c *WSClient) dialRedirect(rawurl string) (conn *websocket.Conn, err error) {
-	for {
+	for i := 0; i < 10; i++ {
 		conn, rawurl, err = c.dial(rawurl)
 		if err != nil {
 			return nil, err
@@ -185,6 +186,7 @@ func (c *WSClient) dialRedirect(rawurl string) (conn *websocket.Conn, err error)
 			return conn, nil
 		}
 	}
+	return nil, errors.New("too many redirects")
 }
 
 func (c *WSClient) dial(rawurl string) (*websocket.Conn, string, error) {

--- a/streaming_ws_test.go
+++ b/streaming_ws_test.go
@@ -340,6 +340,21 @@ func TestDialRedirect(t *testing.T) {
 	}
 }
 
+func TestDialRedirectLoop(t *testing.T) {
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Redirect to ourselves forever.
+		http.Redirect(w, r, ts.URL, http.StatusMovedPermanently)
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{}).NewWSClient()
+	_, err := client.dialRedirect("ws://" + ts.Listener.Addr().String())
+	if err == nil {
+		t.Fatalf("should be fail: %v", err)
+	}
+}
+
 func TestDial(t *testing.T) {
 	canErr := true
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
dialRedirect followed Location headers with no limit, so a server redirecting to itself (or a redirect cycle) made the client loop forever. Cap the redirects at 10 and return an error.