### PR TITLE
Fix JSON marshaling of Unixtime and UnixTimeString

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -72,6 +72,10 @@ func (u *UnixTimeString) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+func (u UnixTimeString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(strconv.FormatInt(u.Unix(), 10))
+}
+
 // History is the history of a followed tag
 type FollowedTagHistory struct {
 	Day      UnixTimeString `json:"day,omitempty"`

--- a/unixtime.go
+++ b/unixtime.go
@@ -18,3 +18,7 @@ func (t *Unixtime) UnmarshalJSON(data []byte) error {
 	*t = Unixtime(time.Unix(ts, 0))
 	return nil
 }
+
+func (t Unixtime) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.FormatInt(time.Time(t).Unix(), 10)), nil
+}

--- a/unixtime_test.go
+++ b/unixtime_test.go
@@ -1,0 +1,52 @@
+package mastodon
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestUnixtimeRoundTrip(t *testing.T) {
+	var ut Unixtime
+	if err := json.Unmarshal([]byte(`1546300800`), &ut); err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if got, want := time.Time(ut).Unix(), int64(1546300800); got != want {
+		t.Fatalf("want %v but %v", want, got)
+	}
+
+	b, err := json.Marshal(ut)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if string(b) != "1546300800" {
+		t.Fatalf("want %q but %q", "1546300800", string(b))
+	}
+}
+
+func TestUnixTimeStringRoundTrip(t *testing.T) {
+	var ut UnixTimeString
+	if err := json.Unmarshal([]byte(`"1546300800"`), &ut); err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if got, want := ut.Unix(), int64(1546300800); got != want {
+		t.Fatalf("want %v but %v", want, got)
+	}
+
+	b, err := json.Marshal(ut)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if string(b) != `"1546300800"` {
+		t.Fatalf("want %q but %q", `"1546300800"`, string(b))
+	}
+
+	// The marshaled form must unmarshal back to the same time.
+	var ut2 UnixTimeString
+	if err := json.Unmarshal(b, &ut2); err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if !ut2.Equal(ut.Time) {
+		t.Fatalf("want %v but %v", ut.Time, ut2.Time)
+	}
+}


### PR DESCRIPTION
Unixtime is a defined type over time.Time, so json.Marshal emitted {} (no exported fields) and dropped the value. UnixTimeString marshaled via the embedded time.Time as an RFC3339 string, which its own UnmarshalJSON cannot parse. Both now marshal as unix epoch (number and string respectively), matching their unmarshalers so values round-trip.