### PR TITLE
Fix instance URLs listing to iterate map keys

### DIFF
--- a/cmd/mstdn/cmd_instance.go
+++ b/cmd/mstdn/cmd_instance.go
@@ -27,7 +27,7 @@ func cmdInstance(c *cli.Context) error {
 	}
 	if instance.URLs != nil {
 		var keys []string
-		for _, k := range instance.URLs {
+		for k := range instance.URLs {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)

--- a/cmd/mstdn/cmd_instance_test.go
+++ b/cmd/mstdn/cmd_instance_test.go
@@ -14,7 +14,7 @@ func TestCmdInstance(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
 			case "/api/v1/instance":
-				fmt.Fprintln(w, `{"title": "zzz"}`)
+				fmt.Fprintln(w, `{"title": "zzz", "urls": {"streaming_api": "wss://example.com"}}`)
 				return
 			}
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
@@ -26,5 +26,8 @@ func TestCmdInstance(t *testing.T) {
 	)
 	if !strings.Contains(out, "zzz") {
 		t.Fatalf("%q should be contained in output of command: %v", "zzz", out)
+	}
+	if !strings.Contains(out, "streaming_api: wss://example.com") {
+		t.Fatalf("%q should be contained in output of command: %v", "streaming_api: wss://example.com", out)
 	}
 }


### PR DESCRIPTION
cmdInstance collected the values of instance.URLs while iterating and then used them as map keys, so `mstdn instance` printed the URL as the label with an empty value (e.g. `wss://...: `) instead of `streaming_api: wss://...`.