### PR TITLE
Fix hashtag output in search command

### DIFF
--- a/cmd/mstdn/cmd_search.go
+++ b/cmd/mstdn/cmd_search.go
@@ -39,7 +39,7 @@ func cmdSearch(c *cli.Context) error {
 	if len(results.Hashtags) > 0 {
 		fmt.Fprintln(c.App.Writer, "===HASHTAG===")
 		for _, result := range results.Hashtags {
-			fmt.Fprintf(c.App.Writer, "#%v\n", result)
+			fmt.Fprintf(c.App.Writer, "#%v\n", result.Name)
 		}
 		fmt.Fprintln(c.App.Writer)
 	}

--- a/cmd/mstdn/cmd_search_test.go
+++ b/cmd/mstdn/cmd_search_test.go
@@ -24,7 +24,7 @@ func TestCmdSearch(t *testing.T) {
 			app.Run([]string{"mstdn", "search", "zzz"})
 		},
 	)
-	for _, s := range []string{"zzz", "yyy", "www", "わろす"} {
+	for _, s := range []string{"zzz", "yyy", "#www", "#わろす"} {
 		if !strings.Contains(out, s) {
 			t.Fatalf("%q should be contained in output of command: %v", s, out)
 		}


### PR DESCRIPTION
Results.Hashtags changed from []string to []*Tag when the library moved to /api/v2/search, but cmdSearch still printed the element directly, so `mstdn search` printed raw structs like `#&{golang https://... [...]}`. Print the tag name.