### PR TITLE
Fix account command to print actual URI

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -24,6 +24,7 @@ type Account struct {
 	StatusesCount  int64          `json:"statuses_count"`
 	Note           string         `json:"note"`
 	URL            string         `json:"url"`
+	URI            string         `json:"uri"`
 	Avatar         string         `json:"avatar"`
 	AvatarStatic   string         `json:"avatar_static"`
 	Header         string         `json:"header"`

--- a/cmd/mstdn/cmd_account.go
+++ b/cmd/mstdn/cmd_account.go
@@ -14,7 +14,7 @@ func cmdAccount(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(c.App.Writer, "URI           : %v\n", account.Acct)
+	fmt.Fprintf(c.App.Writer, "URI           : %v\n", account.URI)
 	fmt.Fprintf(c.App.Writer, "ID            : %v\n", account.ID)
 	fmt.Fprintf(c.App.Writer, "Username      : %v\n", account.Username)
 	fmt.Fprintf(c.App.Writer, "Acct          : %v\n", account.Acct)

--- a/cmd/mstdn/cmd_account_test.go
+++ b/cmd/mstdn/cmd_account_test.go
@@ -14,7 +14,7 @@ func TestCmdAccount(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
 			case "/api/v1/accounts/verify_credentials":
-				fmt.Fprintln(w, `{"username": "zzz"}`)
+				fmt.Fprintln(w, `{"username": "zzz", "uri": "https://example.com/users/zzz"}`)
 				return
 			}
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
@@ -26,5 +26,8 @@ func TestCmdAccount(t *testing.T) {
 	)
 	if !strings.Contains(out, "zzz") {
 		t.Fatalf("%q should be contained in output of command: %v", "zzz", out)
+	}
+	if !strings.Contains(out, "URI           : https://example.com/users/zzz") {
+		t.Fatalf("%q should be contained in output of command: %v", "URI           : https://example.com/users/zzz", out)
 	}
 }


### PR DESCRIPTION
`mstdn account` printed account.Acct twice — once under the URI label and once under Acct — so the account's actual URI was never shown. Add the uri field (Mastodon 4.2+) to the Account entity and print it.