### PR TITLE
Fix minor bugs in mstdn stream and xsearch commands

### DIFF
--- a/cmd/mstdn/cmd_stream.go
+++ b/cmd/mstdn/cmd_stream.go
@@ -65,7 +65,7 @@ func cmdStream(c *cli.Context) error {
 		q, err = client.StreamingPublic(ctx, false)
 	} else if t == "" || t == "public/local" {
 		q, err = client.StreamingPublic(ctx, true)
-	} else if strings.HasPrefix(t, "user:") {
+	} else if t == "user" {
 		q, err = client.StreamingUser(ctx)
 	} else if strings.HasPrefix(t, "hashtag:") {
 		q, err = client.StreamingHashtag(ctx, t[8:], false)

--- a/cmd/mstdn/cmd_stream.go
+++ b/cmd/mstdn/cmd_stream.go
@@ -106,7 +106,9 @@ func cmdStream(c *cli.Context) error {
 				})
 			}
 		} else if asFormat != "" {
-			tx.ExecuteTemplate(c.App.Writer, "mstdn", e)
+			if err := tx.ExecuteTemplate(c.App.Writer, "mstdn", e); err != nil {
+				return err
+			}
 		} else {
 			switch t := e.(type) {
 			case *mastodon.UpdateEvent:

--- a/cmd/mstdn/cmd_xsearch.go
+++ b/cmd/mstdn/cmd_xsearch.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -10,7 +11,10 @@ import (
 )
 
 func cmdXSearch(c *cli.Context) error {
-	return xSearch(c.App.Metadata["xsearch_url"].(string), c.Args().First(), c.App.Writer)
+	if !c.Args().Present() {
+		return errors.New("arguments required")
+	}
+	return xSearch(c.App.Metadata["xsearch_url"].(string), argstr(c), c.App.Writer)
 }
 
 func xSearch(xsearchRawurl, query string, w io.Writer) error {

--- a/cmd/mstdn/main.go
+++ b/cmd/mstdn/main.go
@@ -213,7 +213,7 @@ func makeApp() *cli.App {
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:  "type",
-					Usage: "stream type (public,public/local,user:NAME,hashtag:TAG)",
+					Usage: "stream type (public,public/local,user,hashtag:TAG)",
 				},
 				&cli.BoolFlag{
 					Name:  "json",


### PR DESCRIPTION
Three small fixes in cmd/mstdn, one commit each:

- `--type user` was rejected as invalid while the advertised `user:NAME` form silently ignored NAME (the streaming API only supports the authenticated user). Accept `user` and drop the misleading form from the usage.
- `mstdn xsearch` without arguments queried with an empty string instead of returning "arguments required" like other commands; multi-word queries are now joined like `search`.
- `--template` execution errors were discarded, so a bad template (e.g. unknown field) produced no output and no error for every event.