### PR TITLE
Run cmd/mstdn tests in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,5 +23,7 @@ jobs:
       - run: git diff --cached --exit-code
       - run: go test ./... -v -cover -coverprofile coverage.out
       - run: go test -bench . -benchmem
+      - run: go test ./...
+        working-directory: cmd/mstdn
 
       - uses: codecov/codecov-action@v2


### PR DESCRIPTION
cmd/mstdn is a separate module, so `go test ./...` at the repo root never ran its tests. That's how TestCmdUpload silently rotted when the library moved to the v2 media endpoint (#210). Run the module's tests as a CI step.