### PR TITLE
Add admin accounts and reports API

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -1,0 +1,182 @@
+package mastodon
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// AdminAccount holds the admin-level view of an account.
+type AdminAccount struct {
+	ID            ID        `json:"id"`
+	Username      string    `json:"username"`
+	Domain        string    `json:"domain"`
+	CreatedAt     time.Time `json:"created_at"`
+	Email         string    `json:"email"`
+	IP            string    `json:"ip"`
+	Locale        string    `json:"locale"`
+	InviteRequest string    `json:"invite_request"`
+	Confirmed     bool      `json:"confirmed"`
+	Approved      bool      `json:"approved"`
+	Disabled      bool      `json:"disabled"`
+	Silenced      bool      `json:"silenced"`
+	Suspended     bool      `json:"suspended"`
+	Account       *Account  `json:"account"`
+}
+
+// AdminReport holds the admin-level view of a report.
+type AdminReport struct {
+	ID                   ID            `json:"id"`
+	ActionTaken          bool          `json:"action_taken"`
+	ActionTakenAt        *time.Time    `json:"action_taken_at"`
+	Category             string        `json:"category"`
+	Comment              string        `json:"comment"`
+	Forwarded            bool          `json:"forwarded"`
+	CreatedAt            time.Time     `json:"created_at"`
+	UpdatedAt            time.Time     `json:"updated_at"`
+	Account              *AdminAccount `json:"account"`
+	TargetAccount        *AdminAccount `json:"target_account"`
+	AssignedAccount      *AdminAccount `json:"assigned_account"`
+	ActionTakenByAccount *AdminAccount `json:"action_taken_by_account"`
+	Statuses             []*Status     `json:"statuses"`
+}
+
+// AdminAccountAction specifies a moderation action against an account.
+type AdminAccountAction struct {
+	// Type is one of none, sensitive, disable, silence and suspend.
+	Type                  string
+	Text                  string
+	ReportID              ID
+	WarningPresetID       ID
+	SendEmailNotification bool
+}
+
+// GetAdminAccounts returns accounts from the admin view.
+func (c *Client) GetAdminAccounts(ctx context.Context, pg *Pagination) ([]*AdminAccount, error) {
+	var accounts []*AdminAccount
+	err := c.doAPI(ctx, http.MethodGet, "/api/v1/admin/accounts", nil, &accounts, pg)
+	if err != nil {
+		return nil, err
+	}
+	return accounts, nil
+}
+
+// GetAdminAccount returns an account from the admin view.
+func (c *Client) GetAdminAccount(ctx context.Context, id ID) (*AdminAccount, error) {
+	var account AdminAccount
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/admin/accounts/%s", url.PathEscape(string(id))), nil, &account, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &account, nil
+}
+
+// AdminAccountPerformAction performs a moderation action against the account.
+func (c *Client) AdminAccountPerformAction(ctx context.Context, id ID, action *AdminAccountAction) error {
+	params := url.Values{}
+	params.Set("type", action.Type)
+	if action.Text != "" {
+		params.Set("text", action.Text)
+	}
+	if action.ReportID != "" {
+		params.Set("report_id", string(action.ReportID))
+	}
+	if action.WarningPresetID != "" {
+		params.Set("warning_preset_id", string(action.WarningPresetID))
+	}
+	if action.SendEmailNotification {
+		params.Set("send_email_notification", strconv.FormatBool(action.SendEmailNotification))
+	}
+	return c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/admin/accounts/%s/action", url.PathEscape(string(id))), params, nil, nil)
+}
+
+// AdminAccountApprove approves the pending account.
+func (c *Client) AdminAccountApprove(ctx context.Context, id ID) (*AdminAccount, error) {
+	return c.adminAccountPost(ctx, id, "approve")
+}
+
+// AdminAccountReject rejects the pending account.
+func (c *Client) AdminAccountReject(ctx context.Context, id ID) (*AdminAccount, error) {
+	return c.adminAccountPost(ctx, id, "reject")
+}
+
+// AdminAccountEnable re-enables the disabled account.
+func (c *Client) AdminAccountEnable(ctx context.Context, id ID) (*AdminAccount, error) {
+	return c.adminAccountPost(ctx, id, "enable")
+}
+
+// AdminAccountUnsensitive removes the sensitive flag from the account.
+func (c *Client) AdminAccountUnsensitive(ctx context.Context, id ID) (*AdminAccount, error) {
+	return c.adminAccountPost(ctx, id, "unsensitive")
+}
+
+// AdminAccountUnsilence unsilences the account.
+func (c *Client) AdminAccountUnsilence(ctx context.Context, id ID) (*AdminAccount, error) {
+	return c.adminAccountPost(ctx, id, "unsilence")
+}
+
+// AdminAccountUnsuspend unsuspends the account.
+func (c *Client) AdminAccountUnsuspend(ctx context.Context, id ID) (*AdminAccount, error) {
+	return c.adminAccountPost(ctx, id, "unsuspend")
+}
+
+func (c *Client) adminAccountPost(ctx context.Context, id ID, action string) (*AdminAccount, error) {
+	var account AdminAccount
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/admin/accounts/%s/%s", url.PathEscape(string(id)), action), nil, &account, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &account, nil
+}
+
+// GetAdminReports returns reports from the admin view.
+func (c *Client) GetAdminReports(ctx context.Context, pg *Pagination) ([]*AdminReport, error) {
+	var reports []*AdminReport
+	err := c.doAPI(ctx, http.MethodGet, "/api/v1/admin/reports", nil, &reports, pg)
+	if err != nil {
+		return nil, err
+	}
+	return reports, nil
+}
+
+// GetAdminReport returns a report from the admin view.
+func (c *Client) GetAdminReport(ctx context.Context, id ID) (*AdminReport, error) {
+	var report AdminReport
+	err := c.doAPI(ctx, http.MethodGet, fmt.Sprintf("/api/v1/admin/reports/%s", url.PathEscape(string(id))), nil, &report, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &report, nil
+}
+
+// AdminReportAssignToSelf assigns the report to the current user.
+func (c *Client) AdminReportAssignToSelf(ctx context.Context, id ID) (*AdminReport, error) {
+	return c.adminReportPost(ctx, id, "assign_to_self")
+}
+
+// AdminReportUnassign unassigns the report.
+func (c *Client) AdminReportUnassign(ctx context.Context, id ID) (*AdminReport, error) {
+	return c.adminReportPost(ctx, id, "unassign")
+}
+
+// AdminReportResolve marks the report as resolved.
+func (c *Client) AdminReportResolve(ctx context.Context, id ID) (*AdminReport, error) {
+	return c.adminReportPost(ctx, id, "resolve")
+}
+
+// AdminReportReopen reopens the resolved report.
+func (c *Client) AdminReportReopen(ctx context.Context, id ID) (*AdminReport, error) {
+	return c.adminReportPost(ctx, id, "reopen")
+}
+
+func (c *Client) adminReportPost(ctx context.Context, id ID, action string) (*AdminReport, error) {
+	var report AdminReport
+	err := c.doAPI(ctx, http.MethodPost, fmt.Sprintf("/api/v1/admin/reports/%s/%s", url.PathEscape(string(id)), action), nil, &report, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &report, nil
+}

--- a/admin_test.go
+++ b/admin_test.go
@@ -1,0 +1,269 @@
+package mastodon
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetAdminAccounts(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/admin/accounts" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		fmt.Fprintln(w, `[{"id": "1", "username": "foo", "email": "foo@example.com", "account": {"acct": "foo"}}, {"id": "2", "username": "bar", "suspended": true}]`)
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:      ts.URL,
+		AccessToken: "zoo",
+	})
+	accounts, err := client.GetAdminAccounts(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if len(accounts) != 2 {
+		t.Fatalf("result should be two: %d", len(accounts))
+	}
+	if accounts[0].Email != "foo@example.com" {
+		t.Fatalf("want %q but %q", "foo@example.com", accounts[0].Email)
+	}
+	if accounts[0].Account.Acct != "foo" {
+		t.Fatalf("want %q but %q", "foo", accounts[0].Account.Acct)
+	}
+	if !accounts[1].Suspended {
+		t.Fatalf("want %v but %v", true, accounts[1].Suspended)
+	}
+}
+
+func TestGetAdminAccount(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/admin/accounts/1234567" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		fmt.Fprintln(w, `{"id": "1234567", "username": "foo", "confirmed": true}`)
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:      ts.URL,
+		AccessToken: "zoo",
+	})
+	_, err := client.GetAdminAccount(context.Background(), "123")
+	if err == nil {
+		t.Fatalf("should be fail: %v", err)
+	}
+	account, err := client.GetAdminAccount(context.Background(), "1234567")
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if account.Username != "foo" {
+		t.Fatalf("want %q but %q", "foo", account.Username)
+	}
+	if !account.Confirmed {
+		t.Fatalf("want %v but %v", true, account.Confirmed)
+	}
+}
+
+func TestAdminAccountPerformAction(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/admin/accounts/1234567/action" || r.Method != http.MethodPost {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if r.PostForm.Get("type") != "silence" || r.PostForm.Get("text") != "spam" {
+			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			return
+		}
+		fmt.Fprintln(w, `{}`)
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:      ts.URL,
+		AccessToken: "zoo",
+	})
+	err := client.AdminAccountPerformAction(context.Background(), "1234567", &AdminAccountAction{
+		Type: "silence",
+		Text: "spam",
+	})
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+}
+
+func TestAdminAccountActions(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		switch r.URL.Path {
+		case "/api/v1/admin/accounts/123/approve",
+			"/api/v1/admin/accounts/123/reject",
+			"/api/v1/admin/accounts/123/enable",
+			"/api/v1/admin/accounts/123/unsensitive",
+			"/api/v1/admin/accounts/123/unsilence",
+			"/api/v1/admin/accounts/123/unsuspend":
+			fmt.Fprintln(w, `{"id": "123", "username": "foo"}`)
+			return
+		}
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:      ts.URL,
+		AccessToken: "zoo",
+	})
+	for _, f := range []func(context.Context, ID) (*AdminAccount, error){
+		client.AdminAccountApprove,
+		client.AdminAccountReject,
+		client.AdminAccountEnable,
+		client.AdminAccountUnsensitive,
+		client.AdminAccountUnsilence,
+		client.AdminAccountUnsuspend,
+	} {
+		account, err := f(context.Background(), "123")
+		if err != nil {
+			t.Fatalf("should not be fail: %v", err)
+		}
+		if account.ID != "123" {
+			t.Fatalf("want %q but %q", "123", account.ID)
+		}
+	}
+}
+
+func TestGetAdminReports(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/admin/reports" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		fmt.Fprintln(w, `[{"id": "1", "comment": "spam", "target_account": {"id": "2", "username": "bar"}, "statuses": [{"content": "zzz"}]}]`)
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:      ts.URL,
+		AccessToken: "zoo",
+	})
+	reports, err := client.GetAdminReports(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("result should be one: %d", len(reports))
+	}
+	if reports[0].Comment != "spam" {
+		t.Fatalf("want %q but %q", "spam", reports[0].Comment)
+	}
+	if reports[0].TargetAccount.Username != "bar" {
+		t.Fatalf("want %q but %q", "bar", reports[0].TargetAccount.Username)
+	}
+	if reports[0].Statuses[0].Content != "zzz" {
+		t.Fatalf("want %q but %q", "zzz", reports[0].Statuses[0].Content)
+	}
+}
+
+func TestGetAdminReport(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/admin/reports/1234567" {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		fmt.Fprintln(w, `{"id": "1234567", "action_taken": true}`)
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:      ts.URL,
+		AccessToken: "zoo",
+	})
+	report, err := client.GetAdminReport(context.Background(), "1234567")
+	if err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if !report.ActionTaken {
+		t.Fatalf("want %v but %v", true, report.ActionTaken)
+	}
+}
+
+func TestAdminReportActions(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		switch r.URL.Path {
+		case "/api/v1/admin/reports/123/assign_to_self",
+			"/api/v1/admin/reports/123/unassign",
+			"/api/v1/admin/reports/123/resolve",
+			"/api/v1/admin/reports/123/reopen":
+			fmt.Fprintln(w, `{"id": "123"}`)
+			return
+		}
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:      ts.URL,
+		AccessToken: "zoo",
+	})
+	for _, f := range []func(context.Context, ID) (*AdminReport, error){
+		client.AdminReportAssignToSelf,
+		client.AdminReportUnassign,
+		client.AdminReportResolve,
+		client.AdminReportReopen,
+	} {
+		report, err := f(context.Background(), "123")
+		if err != nil {
+			t.Fatalf("should not be fail: %v", err)
+		}
+		if report.ID != "123" {
+			t.Fatalf("want %q but %q", "123", report.ID)
+		}
+	}
+}
+
+func TestRevokeToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/revoke" || r.Method != http.MethodPost {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if r.PostForm.Get("token") != "zoo" || r.PostForm.Get("client_id") != "foo" || r.PostForm.Get("client_secret") != "bar" {
+			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			return
+		}
+		fmt.Fprintln(w, `{}`)
+	}))
+	defer ts.Close()
+
+	client := NewClient(&Config{
+		Server:       ts.URL,
+		ClientID:     "foo",
+		ClientSecret: "bar",
+		AccessToken:  "zoo",
+	})
+	if err := client.RevokeToken(context.Background()); err != nil {
+		t.Fatalf("should not be fail: %v", err)
+	}
+	if client.Config.AccessToken != "" {
+		t.Fatalf("access token should be cleared: %q", client.Config.AccessToken)
+	}
+}

--- a/mastodon.go
+++ b/mastodon.go
@@ -314,6 +314,21 @@ func (c *Client) getAccessToken(ctx context.Context, params url.Values) error {
 	return nil
 }
 
+// RevokeToken revokes the access token of the client and clears it from the
+// config on success.
+func (c *Client) RevokeToken(ctx context.Context) error {
+	params := url.Values{
+		"client_id":     {c.Config.ClientID},
+		"client_secret": {c.Config.ClientSecret},
+		"token":         {c.Config.AccessToken},
+	}
+	if err := c.doAPI(ctx, http.MethodPost, "/oauth/revoke", params, nil, nil); err != nil {
+		return err
+	}
+	c.Config.AccessToken = ""
+	return nil
+}
+
 // Convenience constants for Toot.Visibility
 const (
 	VisibilityPublic        = "public"


### PR DESCRIPTION
Add /api/v1/admin/accounts and /api/v1/admin/reports endpoints with moderation actions, plus RevokeToken for /oauth/revoke. Fixes #148